### PR TITLE
Use youtube-dl output template with extension parameter #50

### DIFF
--- a/cmd/podsync/updater.go
+++ b/cmd/podsync/updater.go
@@ -21,7 +21,7 @@ import (
 )
 
 type Downloader interface {
-	Download(ctx context.Context, feedConfig *config.Feed, url string, destPath string) (string, error)
+	Download(ctx context.Context, feedConfig *config.Feed, url string, feedPath string, episode *model.Episode) (string, error)
 }
 
 type Updater struct {
@@ -86,7 +86,7 @@ func (u *Updater) Update(ctx context.Context, feedConfig *config.Feed) error {
 		if os.IsNotExist(err) {
 			// There is no file on disk, download episode
 			logger.Infof("! downloading episode %s", episode.VideoURL)
-			if output, err := u.downloader.Download(ctx, feedConfig, episode.VideoURL, episodePath); err == nil {
+			if output, err := u.downloader.Download(ctx, feedConfig, episode.VideoURL, feedPath, episode); err == nil {
 				downloaded++
 			} else {
 				// YouTube might block host with HTTP Error 429: Too Many Requests

--- a/pkg/ytdl/ytdl.go
+++ b/pkg/ytdl/ytdl.go
@@ -2,7 +2,9 @@ package ytdl
 
 import (
 	"context"
+	"fmt"
 	"os/exec"
+	"path/filepath"
 	"time"
 
 	"github.com/pkg/errors"
@@ -38,7 +40,8 @@ func New(ctx context.Context) (*YoutubeDl, error) {
 	return ytdl, nil
 }
 
-func (dl YoutubeDl) Download(ctx context.Context, feedConfig *config.Feed, url string, destPath string) (string, error) {
+func (dl YoutubeDl) Download(ctx context.Context, feedConfig *config.Feed, url string, feedPath string, episode *model.Episode) (string, error) {
+	outputTemplate := youtubeDlOutputTemplate(feedPath, episode)
 	if feedConfig.Format == model.FormatAudio {
 		// Audio
 		if feedConfig.Quality == model.QualityHigh {
@@ -50,7 +53,7 @@ func (dl YoutubeDl) Download(ctx context.Context, feedConfig *config.Feed, url s
 				"--format",
 				"bestaudio",
 				"--output",
-				destPath,
+				outputTemplate,
 				url,
 			)
 		} else { //nolint
@@ -62,7 +65,7 @@ func (dl YoutubeDl) Download(ctx context.Context, feedConfig *config.Feed, url s
 				"--format",
 				"worstaudio",
 				"--output",
-				destPath,
+				outputTemplate,
 				url,
 			)
 		}
@@ -76,7 +79,7 @@ func (dl YoutubeDl) Download(ctx context.Context, feedConfig *config.Feed, url s
 				"--format",
 				"bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best",
 				"--output",
-				destPath,
+				outputTemplate,
 				url,
 			)
 		} else { //nolint
@@ -85,7 +88,7 @@ func (dl YoutubeDl) Download(ctx context.Context, feedConfig *config.Feed, url s
 				"--format",
 				"worstvideo[ext=mp4]+worstaudio[ext=m4a]/worst[ext=mp4]/worst",
 				"--output",
-				destPath,
+				outputTemplate,
 				url,
 			)
 		}
@@ -104,4 +107,9 @@ func (YoutubeDl) exec(ctx context.Context, args ...string) (string, error) {
 	}
 
 	return string(output), nil
+}
+
+func youtubeDlOutputTemplate(feedPath string, episode *model.Episode) string {
+	filename := fmt.Sprintf("%s.%s", episode.ID, "%(ext)s")
+	return filepath.Join(feedPath, filename)
 }


### PR DESCRIPTION
This solves #50.
When `youtube-dl` downloads the original file from youtube it's using the given output template to name the file.

Currently when podsync asks it to download a file and convert it to audio with an output template like `/path/episodeip.mp3`; this causes the original file to be downloaded as  `/path/episodeip.mp3`. Which leads to `ffmpeg` using it as both input and output; this causes `ffmpeg` to exit immediately saying output file already exists. 

As a result, all the files stay as `webm` video files named as `[episodeid].mp3`s. These can't be served by itunes etc.

To reproduce:
```
[server]
port = 80
hostname = "http://localhost"
data_dir = "./data/"

[tokens]
youtube = "[YOUTUBE_TOKEN]"

[feeds]
  [feeds.arsimet]
  url = "https://www.youtube.com/watch?v=gPKLRwSuXwQ&list=PLWXQ0iArMOp-a7rWy84upd7J3tgMv9eZo"
  page_size = 10
  update_period = "6h"
  quality = "high"
  format = "audio"
```

Example `ffprobe GD5xkdt2vwY.mp3 -hide_banner` output:
```
Input #0, matroska,webm, from 'GD5xkdt2vwY.mp3':
  Metadata:
    encoder         : google/video-file
  Duration: 00:17:19.82, start: -0.007000, bitrate: 119 kb/s
    Stream #0:0(eng): Audio: opus, 48000 Hz, stereo, fltp (default)
```

One can see the output saying "output file exists" by adding a line to `ytdl.go:106`
```
log.Infof("youtube-dl output: %s", output)
```

This PR changes causes podsync to use an output template `[episode_id].%(ext)s` which translates to `[episode_id.mp3]` or `[episode_id.mp4]` depending on the configuration. please note that youtube-dl will use `mp3` or `mp4` based on `--format` which is passed in function `Download` in `ytdl.go:41`
