### PR TITLE
Update to latest Youtube Downloader version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.10
 
 WORKDIR /app/
-RUN wget -O /usr/bin/youtube-dl https://github.com/ytdl-org/youtube-dl/releases/download/2019.11.05/youtube-dl && \
+RUN wget -O /usr/bin/youtube-dl https://github.com/ytdl-org/youtube-dl/releases/download/2020.01.24/youtube-dl && \
     chmod +x /usr/bin/youtube-dl && \
     apk --no-cache add ca-certificates python ffmpeg
 COPY podsync /app/podsync


### PR DESCRIPTION
This fixes "ERROR: Signature extraction failed" issue