### PR TITLE
Fix Cron schedule

### DIFF
--- a/cmd/podsync/main.go
+++ b/cmd/podsync/main.go
@@ -130,21 +130,22 @@ func main() {
 		c := cron.New(cron.WithChain(cron.SkipIfStillRunning(nil)))
 
 		for _, feed := range cfg.Feeds {
+			_feed := feed
 			if feed.CronSchedule == "" {
 				feed.CronSchedule = fmt.Sprintf("@every %s", feed.UpdatePeriod.String())
 			}
 
-			if _, err = c.AddFunc(feed.CronSchedule, func() {
-				log.Debugf("adding %q to update queue", feed.URL)
-				updates <- feed
+			if _, err = c.AddFunc(_feed.CronSchedule, func() {
+				log.Debugf("adding %q to update queue", _feed.URL)
+				updates <- _feed
 			}); err != nil {
-				log.WithError(err).Fatalf("can't create cron task for feed: %s", feed.ID)
+				log.WithError(err).Fatalf("can't create cron task for feed: %s", _feed.ID)
 			}
 
-			log.Debugf("-> %s (update '%s')", feed.URL, feed.CronSchedule)
+			log.Debugf("-> %s (update '%s')", _feed.URL, feed.CronSchedule)
 
 			// Perform initial update after CLI restart
-			updates <- feed
+			updates <- _feed
 		}
 
 		c.Start()

--- a/cmd/podsync/updater.go
+++ b/cmd/podsync/updater.go
@@ -68,8 +68,7 @@ func (u *Updater) Update(ctx context.Context, feedConfig *config.Feed) error {
 	}
 
 	elapsed := time.Since(started)
-	nextUpdate := time.Now().Add(feedConfig.UpdatePeriod.Duration)
-	log.Infof("successfully updated feed in %s, next update at %s", elapsed, nextUpdate.Format(time.Kitchen))
+	log.Infof("successfully updated feed in %s", elapsed)
 	return nil
 }
 


### PR DESCRIPTION
Scheduling is wrongly implemented, as consequence all scheduled jobs (functions) will just update the last feed instead of the corresponding one. This is because the variable feed is overwritten inside the loop. 

The fix is based in the former code before cron functionality was added.