### PR TITLE
Improve youtube-dl logging

### DIFF
--- a/cmd/podsync/updater.go
+++ b/cmd/podsync/updater.go
@@ -186,6 +186,7 @@ func (u *Updater) downloadEpisodes(ctx context.Context, feedConfig *config.Feed)
 			// We still need to generate XML, so just stop sending download requests and
 			// retry next time
 			if err == ytdl.ErrTooManyRequests {
+				logger.Warn("server responded with a 'Too Many Requests' error")
 				break
 			}
 

--- a/pkg/ytdl/ytdl.go
+++ b/pkg/ytdl/ytdl.go
@@ -79,6 +79,8 @@ func (dl YoutubeDl) Download(ctx context.Context, feedConfig *config.Feed, episo
 			return nil, ErrTooManyRequests
 		}
 
+		log.Error(output)
+
 		return nil, errors.New(output)
 	}
 


### PR DESCRIPTION
When trying to deploy podsync on a DigitalOcean droplet, I faced with this error:

`youtube-dl error: /tmp/podsync-119127838/17gpOMhVlas.%(ext)s  error="failed to execute youtube-dl: exit status 1"`

There was nothing more in the log that would allow to diagnose the problem further which was not very helpful. This PR makes it a bit easier by explicitly logging a message if a '429 Too Many Requests' error was detected or otherwise dumping the stdout from the youtube-dl command.

(Side note in case someone finds this by googling the error: turns out that due to DO's unique IPv6 allocation policy the /64 block ends up being shared by multiple droplets. Most likely Google considers a /64 block as one user (as it should be) and applies combined rate limits to it. The remedy here is to force IPv4).

