### PR TITLE
Disabled check for ffmpeg.

### DIFF
--- a/pkg/ytdl/ytdl.go
+++ b/pkg/ytdl/ytdl.go
@@ -49,14 +49,6 @@ func New(ctx context.Context) (*YoutubeDl, error) {
 
 	log.Infof("using youtube-dl %s", version)
 
-	// Make sure ffmpeg exists
-	output, err := exec.CommandContext(ctx, "ffmpeg", "-version").CombinedOutput()
-	if err != nil {
-		return nil, errors.Wrap(err, "could not find ffmpeg")
-	}
-
-	log.Infof("using ffmpeg %s", output)
-
 	return ytdl, nil
 }
 


### PR DESCRIPTION
Some Linux distributions (e.g. Debian) have `avconv` instead of ffmpeg. `youtube-dl` can work with either, but podsync insists on having `ffmpeg` in the $PATH. This PR removes the check which allows it to work in Debian. Also, after applying #121 the lack of ffmpeg becomes immediately obvious in the logs:

```
INFO[2020-04-16T13:44:21Z] ! downloading episode https://youtube.com/watch?v=7JFhrFAal74  episode_id=7JFhrFAal74 index=1
ERRO[2020-04-16T13:44:25Z] youtube-dl error: /tmp/podsync-957548525/7JFhrFAal74.%(ext)s  error="failed to execute youtube-dl: exit status 1"
ERRO[2020-04-16T13:44:25Z] [youtube] 7JFhrFAal74: Downloading webpage
[download] Destination: /tmp/podsync-957548525/7JFhrFAal74.m4a
[download] 100% of 8.22MiB in 00:0039MiB/s ETA 00:000nown ETA
WARNING: 7JFhrFAal74: writing DASH m4a. Only some players support this container. Install ffmpeg or avconv to fix this automatically.
ERROR: ffprobe/avprobe and ffmpeg/avconv not found. Please install one. 
```