### PR TITLE
Added configurable command line options for youtube-dl.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ vimeo = "{VIMEO_API_TOKEN}"
   # filters = { title = "regex for title here" } # Optional Golang regexp format. If set, then only download episodes with matching titles.
   # opml = true|false # Optional inclusion of the feed in the OPML file (default value: false)
   # clean = { keep_last = 10 } # Keep last 10 episodes (order desc by PubDate)
+  # downloader_opts = [ "-4", "--verbose" ] # Custom command line options for the downloader (youtube-dl)
 
 [database]
   badger = { truncate = true, file_io = true } # See https://github.com/dgraph-io/badger#memory-usage

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -44,6 +44,8 @@ type Feed struct {
 	Custom Custom `toml:"custom"`
 	// Included in OPML file
 	OPML bool `toml:"opml"`
+	// Additional downloader command line options
+	DownloaderOpts []string `toml:"downloader_opts"`
 }
 
 type Custom struct {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -35,6 +35,7 @@ dir = "/home/user/db/"
   filters = { title = "regex for title here" }
   clean = { keep_last = 10 }
   custom = { cover_art = "http://img", category = "TV", explicit = true, lang = "en" }
+  downloader_opts = [ "--verbose", "-4" ]
 `
 	path := setup(t, file)
 	defer os.Remove(path)
@@ -66,6 +67,7 @@ dir = "/home/user/db/"
 	assert.EqualValues(t, "TV", feed.Custom.Category)
 	assert.True(t, feed.Custom.Explicit)
 	assert.EqualValues(t, "en", feed.Custom.Language)
+	assert.EqualValues(t, []string{"--verbose", "-4"}, feed.DownloaderOpts)
 
 	assert.Nil(t, config.Database.Badger)
 }

--- a/pkg/ytdl/ytdl.go
+++ b/pkg/ytdl/ytdl.go
@@ -110,7 +110,7 @@ func (dl YoutubeDl) exec(ctx context.Context, args ...string) (string, error) {
 }
 
 func buildArgs(feedConfig *config.Feed, episode *model.Episode, outputFilePath string) []string {
-	var args []string
+	args := append([]string{}, feedConfig.DownloaderOpts...)
 
 	if feedConfig.Format == model.FormatVideo {
 		// Video, mp4, high by default


### PR DESCRIPTION
As I mentioned in #121 in order to make it work more reliably in Digital Ocean it is needed to force youtube-dl to use IPv4 rather than IPv6. This PR adds an ability to specify custom additional options for a feed downloader. It also may be useful for debugging (which you can enable to adding '--verbose').

The rationale for making it feed specific rather than global is future proofing: there may be other downloading tools or mechanisms and they may be feed specific.