### PR TITLE
Support log rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,15 @@ vimeo = "{VIMEO_API_TOKEN}"
 
 [database]
   badger = { truncate = true, file_io = true } # See https://github.com/dgraph-io/badger#memory-usage
+
+# Optional log config. If not specified logs to the stdout
+[log]
+filename = "podsync.log"
+max_size = 50 # MB
+max_age = 30 # days
+max_backups = 7
+compress = true
+
 ```
 
 Episodes files will be kept at: `/path/to/data/directory/ID1`, feed will be accessible from: `http://localhost/ID1.xml`

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	google.golang.org/api v0.0.0-20180718221112-efcb5f25ac56
 	google.golang.org/appengine v1.1.0 // indirect
+	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -91,7 +91,11 @@ google.golang.org/api v0.0.0-20180718221112-efcb5f25ac56 h1:iDRbkenn0VZEo05mHiCt
 google.golang.org/api v0.0.0-20180718221112-efcb5f25ac56/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/appengine v1.1.0 h1:igQkv0AAhEIvTEpD5LIpAfav2eeVO9HBTjvKHVJPRSs=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/natefinch/lumberjack.v2 v2.0.0 h1:1Lc07Kr7qY4U2YPouBjpCLxpiyxIVoxqXgkXLknAOE8=
+gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -90,9 +90,24 @@ type Cleanup struct {
 	KeepLast int `toml:"keep_last"`
 }
 
+type Log struct {
+	// Filename to write the log to (instead of stdout)
+	Filename string `toml:"filename"`
+	// MaxSize is the maximum size of the log file in MB
+	MaxSize int `toml:"max_size"`
+	// MaxBackups is the maximum number of log file backups to keep after rotation
+	MaxBackups int `toml:"max_backups"`
+	// MaxAge is the maximum number of days to keep the logs for
+	MaxAge int `toml:"max_age"`
+	// Compress old backups
+	Compress bool `toml:"compress"`
+}
+
 type Config struct {
 	// Server is the web server configuration
 	Server Server `toml:"server"`
+	// Log is the optional logging configuration
+	Log Log `toml:"log"`
 	// Database configuration
 	Database Database `toml:"database"`
 	// Feeds is a list of feeds to host by this app.
@@ -149,6 +164,18 @@ func (c *Config) applyDefaults(configPath string) {
 			c.Server.Hostname = fmt.Sprintf("http://localhost:%d", c.Server.Port)
 		} else {
 			c.Server.Hostname = "http://localhost"
+		}
+	}
+
+	if c.Log.Filename != "" {
+		if c.Log.MaxSize == 0 {
+			c.Log.MaxSize = model.DefaultLogMaxSize
+		}
+		if c.Log.MaxAge == 0 {
+			c.Log.MaxAge = model.DefaultLogMaxAge
+		}
+		if c.Log.MaxBackups == 0 {
+			c.Log.MaxBackups = model.DefaultLogMaxBackups
 		}
 	}
 

--- a/pkg/db/badger.go
+++ b/pkg/db/badger.go
@@ -42,7 +42,7 @@ func NewBadger(config *config.Database) (*Badger, error) {
 	}
 
 	opts := badger.DefaultOptions(dir).
-		WithLogger(log.New()).
+		WithLogger(log.StandardLogger()).
 		WithTruncate(true)
 
 	if config.Badger != nil {

--- a/pkg/model/defaults.go
+++ b/pkg/model/defaults.go
@@ -5,8 +5,11 @@ import (
 )
 
 const (
-	DefaultFormat       = FormatVideo
-	DefaultQuality      = QualityHigh
-	DefaultPageSize     = 50
-	DefaultUpdatePeriod = 6 * time.Hour
+	DefaultFormat        = FormatVideo
+	DefaultQuality       = QualityHigh
+	DefaultPageSize      = 50
+	DefaultUpdatePeriod  = 6 * time.Hour
+	DefaultLogMaxSize    = 50 // megabytes
+	DefaultLogMaxAge     = 30 // days
+	DefaultLogMaxBackups = 7
 )


### PR DESCRIPTION
Currently the logging is done via printing to the standard output. When running podsync as a background service for a long time this becomes a problem because there is no way to delete old logs without restarting the service.

This PR adds support for log rotation using [lumberjack](https://github.com/natefinch/lumberjack ). The logging is controlled by an option section in the log file. If this section is not present, the current behaviour is maintained.