### PR TITLE
Introduce OPML export functionality

### DIFF
--- a/cmd/podsync/opml.go
+++ b/cmd/podsync/opml.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"encoding/xml"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/mxpv/podsync/pkg/config"
+)
+
+func getOPML(feeds map[string]*config.Feed, server *config.Server) (doc *string, err error) {
+	outlines := []Outline{}
+	for name := range feeds {
+		outlines = append(outlines, Outline{
+			XMLURL: server.Hostname + "/" + name + ".xml",
+			Text:   name,
+			Type:   "rss",
+		})
+	}
+	body := Body{
+		Outlines: outlines,
+	}
+	root := OPML{
+		Version: "1.0",
+		Body:    body,
+		Head: Head{
+			Title: "Podsync Feeds",
+		},
+	}
+	out, err := xml.MarshalIndent(root, "", "  ")
+	if err != nil {
+		log.Error("Error creating OPML file failed")
+		return nil, err
+	}
+	xmlDoc := xml.Header + string(out) + "\n"
+	return &xmlDoc, nil
+}
+
+type OPML struct {
+	XMLName xml.Name `xml:"opml"`
+	Version string   `xml:"version,attr"`
+	Head    Head     `xml:"head"`
+	Body    Body     `xml:"body"`
+}
+
+type Head struct {
+	Title string `xml:"title"`
+}
+
+type Body struct {
+	Outlines []Outline `xml:"outline"`
+}
+
+type Outline struct {
+	XMLURL string `xml:"xmlUrl,attr"`
+	Text   string `xml:"title,attr"`
+	Type   string `xml:"type,attr"`
+}


### PR DESCRIPTION
If you amass even a medium amount of feeds importing them into your favourite Podcast client can be a laborious task. Most Podcast players offer an OPML import, so this PR adds the capability to save the feeds to an OPML file or print the OPML to stdout.

If you have suggestions as to improving the CLI interface for this I would be open to them.
I am by no means a go expert, so let me know if there are changes you'd want!

The exported file was tested in Gnome Podcasts and Pocketcasts and seems to work fine.