### PR TITLE
Implemented negative filters for title and description.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ vimeo = [ # Multiple keys will be rotated.
   # custom = { cover_art = "{IMAGE_URL}}", category = "TV", explicit = true, lang = "en" } # Optional feed customizations
   # max_height = "720" # Optional maximal height of video, example: 720, 1080, 1440, 2160, ...
   # cron_schedule = "@every 12h" # Optional cron expression format. If set then overwrite 'update_period'. See details below
-  # filters = { title = "regex for title here" } # Optional Golang regexp format. If set, then only download episodes with matching titles.
+  # filters = { title = "regex for title here", not_title = "regex for negative title match", description = "...", not_description = "..." } # Optional Golang regexp format. If set, then only download matching episodes.
   # opml = true|false # Optional inclusion of the feed in the OPML file (default value: false)
   # clean = { keep_last = 10 } # Keep last 10 episodes (order desc by PubDate)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -45,7 +45,10 @@ type Feed struct {
 }
 
 type Filters struct {
-	Title string `toml:"title"`
+	Title          string `toml:"title"`
+	NotTitle       string `toml:"not_title"`
+	Description    string `toml:"description"`
+	NotDescription string `toml:"not_description"`
 	// More filters to be added here
 }
 


### PR DESCRIPTION
I'd like to filter out episodes with certain keywords in the title or description. Because Go's regexp engine does not support negative lookaheads it is not possible to do this just by specifying a regexp for title.

I considered the following approaches:
- Switching to a different regexp engine (extra dependency, not good).
- Introducing a special syntax for negative filters, e.g. prepending the filter regexp with '!' (hacky).
- Adding separate negative filters.

In the end I've decided in favour of the last approach. This PR adds negative filters for title as well as positive and negative filters for description.
