### PR TITLE
Only consider downloaded episodes when cleaning

### DIFF
--- a/cmd/podsync/updater.go
+++ b/cmd/podsync/updater.go
@@ -346,10 +346,7 @@ func (u *Updater) cleanup(ctx context.Context, feedConfig *config.Feed) error {
 
 	logger.WithField("count", count).Info("running cleaner")
 	if err := u.db.WalkEpisodes(ctx, feedConfig.ID, func(episode *model.Episode) error {
-		switch episode.Status {
-		case model.EpisodeError, model.EpisodeCleaned:
-			// Skip
-		default:
+		if episode.Status == model.EpisodeDownloaded {
 			list = append(list, episode)
 		}
 		return nil


### PR DESCRIPTION
If an episode was not dowloaded because it did not match filters, it is still counted towards the limit during cleanup. This PR makes sure only downloaded episodes are counted. 