### PR TITLE
Cleanup improvements

### DIFF
--- a/pkg/db/badger.go
+++ b/pkg/db/badger.go
@@ -214,6 +214,13 @@ func (b *Badger) UpdateEpisode(feedID string, episodeID string, cb func(episode 
 	})
 }
 
+func (b *Badger) DeleteEpisode(feedID, episodeID string) error {
+	key := b.getKey(episodePath, feedID, episodeID)
+	return b.db.Update(func(txn *badger.Txn) error {
+		return txn.Delete(key)
+	})
+}
+
 func (b *Badger) WalkEpisodes(ctx context.Context, feedID string, cb func(episode *model.Episode) error) error {
 	return b.db.View(func(txn *badger.Txn) error {
 		return b.walkEpisodes(txn, feedID, cb)

--- a/pkg/db/storage.go
+++ b/pkg/db/storage.go
@@ -36,6 +36,9 @@ type Storage interface {
 	// UpdateEpisode updates episode fields
 	UpdateEpisode(feedID string, episodeID string, cb func(episode *model.Episode) error) error
 
+	// DeleteEpisode deletes an episode
+	DeleteEpisode(feedID string, episodeID string) error
+
 	// WalkEpisodes iterates over episodes that belong to the given feed ID
 	WalkEpisodes(ctx context.Context, feedID string, cb func(episode *model.Episode) error) error
 }


### PR DESCRIPTION
I've run into the following issue: a youtube stream was initially announced, got into podsync db, then it was deleted. However, because it was still in the db, podsync was trying to download it every time.

This PR deletes episodes that have not been downloaded for some reason (either due to the situation described above or because they did not match the filters) and are no longer available in the feed.

Also, when cleaning up an episode its title and description are set to "" to conserve some space. I probably should have split this into two, happy to do so if you don't like this change.