### PR TITLE
Use H.264 codec first

### DIFF
--- a/pkg/ytdl/ytdl.go
+++ b/pkg/ytdl/ytdl.go
@@ -195,12 +195,12 @@ func buildArgs(feedConfig *config.Feed, episode *model.Episode, outputFilePath s
 	if feedConfig.Format == model.FormatVideo {
 		// Video, mp4, high by default
 
-		format := "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best"
+		format := "bestvideo[ext=mp4][vcodec^=avc1]+bestaudio[ext=m4a]/best[ext=mp4][vcodec^=avc1]/best[ext=mp4]/best"
 
 		if feedConfig.Quality == model.QualityLow {
-			format = "worstvideo[ext=mp4]+worstaudio[ext=m4a]/worst[ext=mp4]/worst"
+			format = "worstvideo[ext=mp4][vcodec^=avc1]+worstaudio[ext=m4a]/worst[ext=mp4][vcodec^=avc1]/worst[ext=mp4]/worst"
 		} else if feedConfig.Quality == model.QualityHigh && feedConfig.MaxHeight > 0 {
-			format = fmt.Sprintf("bestvideo[height<=%d][ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best", feedConfig.MaxHeight)
+			format = fmt.Sprintf("bestvideo[height<=%d][ext=mp4][vcodec^=avc1]+bestaudio[ext=m4a]/best[height<=%d][ext=mp4][vcodec^=avc1]/best[ext=mp4]/best", feedConfig.MaxHeight, feedConfig.MaxHeight)
 		}
 
 		args = append(args, "--format", format)

--- a/pkg/ytdl/ytdl_test.go
+++ b/pkg/ytdl/ytdl_test.go
@@ -48,7 +48,7 @@ func TestBuildArgs(t *testing.T) {
 			format:   model.FormatVideo,
 			output:   "/tmp/1",
 			videoURL: "http://url",
-			expect:   []string{"--format", "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best", "--output", "/tmp/1", "http://url"},
+			expect:   []string{"--format", "bestvideo[ext=mp4][vcodec^=avc1]+bestaudio[ext=m4a]/best[ext=mp4][vcodec^=avc1]/best[ext=mp4]/best", "--output", "/tmp/1", "http://url"},
 		},
 		{
 			name:      "Video unknown quality with maxheight",
@@ -56,7 +56,7 @@ func TestBuildArgs(t *testing.T) {
 			maxHeight: 720,
 			output:    "/tmp/1",
 			videoURL:  "http://url",
-			expect:    []string{"--format", "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best", "--output", "/tmp/1", "http://url"},
+			expect:    []string{"--format", "bestvideo[ext=mp4][vcodec^=avc1]+bestaudio[ext=m4a]/best[ext=mp4][vcodec^=avc1]/best[ext=mp4]/best", "--output", "/tmp/1", "http://url"},
 		},
 		{
 			name:     "Video low quality",
@@ -64,7 +64,7 @@ func TestBuildArgs(t *testing.T) {
 			quality:  model.QualityLow,
 			output:   "/tmp/2",
 			videoURL: "http://url",
-			expect:   []string{"--format", "worstvideo[ext=mp4]+worstaudio[ext=m4a]/worst[ext=mp4]/worst", "--output", "/tmp/2", "http://url"},
+			expect:   []string{"--format", "worstvideo[ext=mp4][vcodec^=avc1]+worstaudio[ext=m4a]/worst[ext=mp4][vcodec^=avc1]/worst[ext=mp4]/worst", "--output", "/tmp/2", "http://url"},
 		},
 		{
 			name:      "Video low quality with maxheight",
@@ -73,7 +73,7 @@ func TestBuildArgs(t *testing.T) {
 			maxHeight: 720,
 			output:    "/tmp/2",
 			videoURL:  "http://url",
-			expect:    []string{"--format", "worstvideo[ext=mp4]+worstaudio[ext=m4a]/worst[ext=mp4]/worst", "--output", "/tmp/2", "http://url"},
+			expect:    []string{"--format", "worstvideo[ext=mp4][vcodec^=avc1]+worstaudio[ext=m4a]/worst[ext=mp4][vcodec^=avc1]/worst[ext=mp4]/worst", "--output", "/tmp/2", "http://url"},
 		},
 		{
 			name:     "Video high quality",
@@ -81,7 +81,7 @@ func TestBuildArgs(t *testing.T) {
 			quality:  model.QualityHigh,
 			output:   "/tmp/2",
 			videoURL: "http://url1",
-			expect:   []string{"--format", "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best", "--output", "/tmp/2", "http://url1"},
+			expect:   []string{"--format", "bestvideo[ext=mp4][vcodec^=avc1]+bestaudio[ext=m4a]/best[ext=mp4][vcodec^=avc1]/best[ext=mp4]/best", "--output", "/tmp/2", "http://url1"},
 		},
 		{
 			name:      "Video high quality with maxheight",
@@ -90,7 +90,7 @@ func TestBuildArgs(t *testing.T) {
 			maxHeight: 1024,
 			output:    "/tmp/2",
 			videoURL:  "http://url1",
-			expect:    []string{"--format", "bestvideo[height<=1024][ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best", "--output", "/tmp/2", "http://url1"},
+			expect:    []string{"--format", "bestvideo[height<=1024][ext=mp4][vcodec^=avc1]+bestaudio[ext=m4a]/best[height<=1024][ext=mp4][vcodec^=avc1]/best[ext=mp4]/best", "--output", "/tmp/2", "http://url1"},
 		},
 		{
 			name:     "Video high quality with custom youtube-dl arguments",
@@ -99,7 +99,7 @@ func TestBuildArgs(t *testing.T) {
 			output:   "/tmp/2",
 			videoURL: "http://url1",
 			ytdlArgs: []string{"--write-sub", "--embed-subs", "--sub-lang", "en,en-US,en-GB"},
-			expect:   []string{"--format", "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best", "--write-sub", "--embed-subs", "--sub-lang", "en,en-US,en-GB", "--output", "/tmp/2", "http://url1"},
+			expect:   []string{"--format", "bestvideo[ext=mp4][vcodec^=avc1]+bestaudio[ext=m4a]/best[ext=mp4][vcodec^=avc1]/best[ext=mp4]/best", "--write-sub", "--embed-subs", "--sub-lang", "en,en-US,en-GB", "--output", "/tmp/2", "http://url1"},
 		},
 	}
 


### PR DESCRIPTION
This pull request improves the portability of the video.

Very occasionally, YouTube publishes videos that combine the AV1 codec and MP4 containers.
AV1+MP4 video was downloaded when I specified the `quality = "low", format = "video"` option (see below).

```bash
# tested in youtube-dl 2020.09.20

# Use original 'low' format
$ youtube-dl -f 'worstvideo[ext=mp4]+worstaudio[ext=m4a]/worst[ext=mp4]/worst' DIe_PXlpRd0 --output 'video_%(vcodec)s.%(ext)s'

# => creates video_av01.0.00M.08.0.110.01.01.06.0.f394.mp4
```

Most podcast players don't support the AV1 codec, so I changed to select H.264 (AVC) codec first.
