### PR TITLE
Support overwriting title, author and description of feed

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -55,12 +55,12 @@ type Filters struct {
 }
 
 type Custom struct {
-	CoverArt string    `toml:"cover_art"`
-	Category string    `toml:"category"`
-	Explicit bool      `toml:"explicit"`
-	Language string    `toml:"lang"`
-	Author string 	    `toml:"author"`
-	Title string       `toml:"title"`
+	CoverArt    string `toml:"cover_art"`
+	Category    string `toml:"category"`
+	Explicit    bool   `toml:"explicit"`
+	Language    string `toml:"lang"`
+	Author      string `toml:"author"`
+	Title       string `toml:"title"`
 	Description string `toml:"description"`
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,12 +17,6 @@ type Feed struct {
 	ID string `toml:"-"`
 	// URL is a full URL of the field
 	URL string `toml:"url"`
-	// Optional overwrite for title
-	Author string `toml:"author"`
-	// Optional overwrite for title
-	Title string `toml:"title"`
-	// Optional overwrite for descriptiom
-	Description string `toml:"description"`
 	// PageSize is the number of pages to query from YouTube API.
 	// NOTE: larger page sizes/often requests might drain your API token.
 	PageSize int `toml:"page_size"`
@@ -61,10 +55,13 @@ type Filters struct {
 }
 
 type Custom struct {
-	CoverArt string `toml:"cover_art"`
-	Category string `toml:"category"`
-	Explicit bool   `toml:"explicit"`
-	Language string `toml:"lang"`
+	CoverArt string    `toml:"cover_art"`
+	Category string    `toml:"category"`
+	Explicit bool      `toml:"explicit"`
+	Language string    `toml:"lang"`
+	Author string 	    `toml:"author"`
+	Title string       `toml:"title"`
+	Description string `toml:"description"`
 }
 
 type Server struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,6 +17,12 @@ type Feed struct {
 	ID string `toml:"-"`
 	// URL is a full URL of the field
 	URL string `toml:"url"`
+	// Optional overwrite for title
+	Author string `toml:"author"`
+	// Optional overwrite for title
+	Title string `toml:"title"`
+	// Optional overwrite for descriptiom
+	Description string `toml:"description"`
 	// PageSize is the number of pages to query from YouTube API.
 	// NOTE: larger page sizes/often requests might drain your API token.
 	PageSize int `toml:"page_size"`

--- a/pkg/feed/xml.go
+++ b/pkg/feed/xml.go
@@ -37,9 +37,9 @@ func Build(ctx context.Context, feed *model.Feed, cfg *config.Feed, provider url
 	)
 
 	var (
-		now = time.Now().UTC()
-		author = feed.Title
-		title = feed.Title
+		now         = time.Now().UTC()
+		author      = feed.Title
+		title       = feed.Title
 		description = feed.Description
 	)
 

--- a/pkg/feed/xml.go
+++ b/pkg/feed/xml.go
@@ -38,13 +38,28 @@ func Build(ctx context.Context, feed *model.Feed, cfg *config.Feed, provider url
 
 	var (
 		now = time.Now().UTC()
+		author = feed.Author
+		title = feed.Title
+		description = feed.Description
 	)
 
-	p := itunes.New(feed.Title, feed.ItemURL, feed.Description, &feed.PubDate, &now)
+	if cfg.Author != "" {
+		author = cfg.Author
+	}
+
+	if cfg.Title != "" {
+		title = cfg.Title
+	}
+
+	if cfg.Description != "" {
+		description = cfg.Description
+	}
+
+	p := itunes.New(title, feed.ItemURL, description, &feed.PubDate, &now)
 	p.Generator = podsyncGenerator
-	p.AddSubTitle(feed.Title)
-	p.IAuthor = feed.Title
-	p.AddSummary(feed.Description)
+	p.AddSubTitle(title)
+	p.IAuthor = author
+	p.AddSummary(description)
 
 	if cfg.Custom.CoverArt != "" {
 		p.AddImage(cfg.Custom.CoverArt)

--- a/pkg/feed/xml.go
+++ b/pkg/feed/xml.go
@@ -38,7 +38,7 @@ func Build(ctx context.Context, feed *model.Feed, cfg *config.Feed, provider url
 
 	var (
 		now = time.Now().UTC()
-		author = feed.Author
+		author = feed.Title
 		title = feed.Title
 		description = feed.Description
 	)

--- a/pkg/feed/xml.go
+++ b/pkg/feed/xml.go
@@ -43,16 +43,16 @@ func Build(ctx context.Context, feed *model.Feed, cfg *config.Feed, provider url
 		description = feed.Description
 	)
 
-	if cfg.Author != "" {
-		author = cfg.Author
+	if cfg.Custom.Author != "" {
+		author = cfg.Custom.Author
 	}
 
-	if cfg.Title != "" {
-		title = cfg.Title
+	if cfg.Custom.Title != "" {
+		title = cfg.Custom.Title
 	}
 
-	if cfg.Description != "" {
-		description = cfg.Description
+	if cfg.Custom.Description != "" {
+		description = cfg.Custom.Description
 	}
 
 	p := itunes.New(title, feed.ItemURL, description, &feed.PubDate, &now)


### PR DESCRIPTION
Support overwriting title, author and description of feed in config.toml

Fixes #176