### PR TITLE
Make the hard timeout on youtube-dl execution configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ vimeo = [ # Multiple keys will be rotated.
   # custom.cover_art_quality use "high" or "low" to special cover image quality from channel cover default is equal with "quality" and disable when custom.cover_art was set.
   # custom = { cover_art = "{IMAGE_URL}}", cover_art_quality = "high", category = "TV", subcategories = ["Documentary", "Tech News"], explicit = true, lang = "en" } # Optional feed customizations
   # max_height = 720 # Optional maximal height of video, example: 720, 1080, 1440, 2160, ...
-  # download_timeout = 30 #Timeout for downloading a video (in minutes) after which youtube-dl will be killed
   # cron_schedule = "@every 12h" # Optional cron expression format. If set then overwrite 'update_period'. See details below
   # filters = { title = "regex for title here", not_title = "regex for negative title match", description = "...", not_description = "..." } # Optional Golang regexp format. If set, then only download matching episodes.
   # opml = true|false # Optional inclusion of the feed in the OPML file (default value: false)
@@ -89,6 +88,7 @@ vimeo = [ # Multiple keys will be rotated.
 
 [downloader]
 self_update = true # Optional, auto update youtube-dl every 24 hours
+# download_timeout = 30 #Timeout for downloading a video (in minutes) after which youtube-dl will be killed
 
 # Optional log config. If not specified logs to the stdout
 [log]

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ vimeo = [ # Multiple keys will be rotated.
   # custom.cover_art_quality use "high" or "low" to special cover image quality from channel cover default is equal with "quality" and disable when custom.cover_art was set.
   # custom = { cover_art = "{IMAGE_URL}}", cover_art_quality = "high", category = "TV", subcategories = ["Documentary", "Tech News"], explicit = true, lang = "en" } # Optional feed customizations
   # max_height = 720 # Optional maximal height of video, example: 720, 1080, 1440, 2160, ...
+  # download_timeout = 30 #Timeout for downloading a video (in minutes) after which youtube-dl will be killed
   # cron_schedule = "@every 12h" # Optional cron expression format. If set then overwrite 'update_period'. See details below
   # filters = { title = "regex for title here", not_title = "regex for negative title match", description = "...", not_description = "..." } # Optional Golang regexp format. If set, then only download matching episodes.
   # opml = true|false # Optional inclusion of the feed in the OPML file (default value: false)

--- a/cmd/podsync/main.go
+++ b/cmd/podsync/main.go
@@ -97,7 +97,7 @@ func main() {
 		"date":    date,
 	}).Info("running podsync")
 
-	downloader, err := ytdl.New(ctx, cfg.Downloader.SelfUpdate)
+	downloader, err := ytdl.New(ctx, cfg.Downloader.SelfUpdate, cfg.Feed)
 	if err != nil {
 		log.WithError(err).Fatal("youtube-dl error")
 	}

--- a/cmd/podsync/main.go
+++ b/cmd/podsync/main.go
@@ -97,7 +97,7 @@ func main() {
 		"date":    date,
 	}).Info("running podsync")
 
-	downloader, err := ytdl.New(ctx, cfg.Downloader.SelfUpdate, cfg.Feed)
+	downloader, err := ytdl.New(ctx, cfg.Downloader.SelfUpdate, cfg.Downloader.DownloadTimeoutMin)
 	if err != nil {
 		log.WithError(err).Fatal("youtube-dl error")
 	}
@@ -132,7 +132,7 @@ func main() {
 		for {
 			select {
 			case feed := <-updates:
-				if err := updater.Update(ctx, feed); err != nil {
+				if err := updater.Update(ctx, feed, cfg.Downloader.DownloadTimeoutMin); err != nil {
 					log.WithError(err).Errorf("failed to update feed: %s", feed.URL)
 				} else {
 					log.Infof("next update of %s: %s", feed.ID, c.Entry(m[feed.ID]).Next)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,6 +32,8 @@ type Feed struct {
 	Quality model.Quality `toml:"quality"`
 	// Maximum height of video
 	MaxHeight int `toml:"max_height"`
+	// Timeout for downloading a video (in minutes) after which youtube-dl will be killed
+	DownloadTimeoutMin int `toml:"download_timeout"`
 	// Format to use for this feed
 	Format model.Format `toml:"format"`
 	// Only download episodes that match this regexp (defaults to matching anything)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,8 +32,6 @@ type Feed struct {
 	Quality model.Quality `toml:"quality"`
 	// Maximum height of video
 	MaxHeight int `toml:"max_height"`
-	// Timeout for downloading a video (in minutes) after which youtube-dl will be killed
-	DownloadTimeoutMin int `toml:"download_timeout"`
 	// Format to use for this feed
 	Format model.Format `toml:"format"`
 	// Only download episodes that match this regexp (defaults to matching anything)
@@ -113,6 +111,8 @@ type Log struct {
 type Downloader struct {
 	// SelfUpdate toggles self update every 24 hour
 	SelfUpdate bool `toml:"self_update"`
+	// Timeout for downloading a video (in minutes) after which youtube-dl will be killed
+	DownloadTimeoutMin int `toml:"download_timeout"`
 }
 
 type Config struct {


### PR DESCRIPTION
Right now the timeout for youtube-dl is hard coded. After 10 minutes youtube-dl is killed no question asked.

This pull request make this timeout an optional setting from config.toml and change the default to 30 minutes.

This is my first dab at Go, but at least it seems to work for me.