### PR TITLE
Add Podcast Owner Custom Definitions

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -65,6 +65,8 @@ type Custom struct {
 	Author          string        `toml:"author"`
 	Title           string        `toml:"title"`
 	Description     string        `toml:"description"`
+	OwnerName       string        `toml:"ownerName"`
+	OwnerEmail      string        `toml:"ownerEmail"`
 }
 
 type Server struct {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -41,17 +41,16 @@ timeout = 15
   quality = "low"
   filters = { title = "regex for title here" }
   clean = { keep_last = 10 }
-  custom = { 
-	  cover_art = "http://img", 
-	  cover_art_quality = "high", 
-	  category = "TV", 
-	  subcategories = ["1", "2"], 
-	  explicit = true, 
-	  lang = "en",
-	  author = "Mrs. Smith (mrs@smith.org)",
-	  ownerName = "Mrs. Smith",
-	  ownerEmail = "mrs@smith.org"
-	}
+  	[feeds.XYZ.custom]
+	cover_art = "http://img"
+	cover_art_quality = "high"
+	category = "TV"
+	subcategories = ["1", "2"]
+	explicit = true
+	lang = "en"
+	author = "Mrs. Smith (mrs@smith.org)"
+	ownerName = "Mrs. Smith"
+	ownerEmail = "mrs@smith.org"
 `
 	path := setup(t, file)
 	defer os.Remove(path)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -41,7 +41,17 @@ timeout = 15
   quality = "low"
   filters = { title = "regex for title here" }
   clean = { keep_last = 10 }
-  custom = { cover_art = "http://img", cover_art_quality = "high", category = "TV", subcategories = ["1", "2"],  explicit = true, lang = "en" }
+  custom = { 
+	  cover_art = "http://img", 
+	  cover_art_quality = "high", 
+	  category = "TV", 
+	  subcategories = ["1", "2"], 
+	  explicit = true, 
+	  lang = "en",
+	  author = "Mrs. Smith (mrs@smith.org)",
+	  ownerName = "Mrs. Smith",
+	  ownerEmail = "mrs@smith.org"
+	}
 `
 	path := setup(t, file)
 	defer os.Remove(path)
@@ -77,6 +87,9 @@ timeout = 15
 	assert.EqualValues(t, "TV", feed.Custom.Category)
 	assert.True(t, feed.Custom.Explicit)
 	assert.EqualValues(t, "en", feed.Custom.Language)
+	assert.EqualValues(t, "Mrs. Smith (mrs@smith.org)", feed.Custom.Author)
+	assert.EqualValues(t, "Mrs. Smith", feed.Custom.OwnerName)
+	assert.EqualValues(t, "mrs@smith.org", feed.Custom.OwnerEmail)
 
 	assert.EqualValues(t, feed.Custom.Subcategories, []string{"1", "2"})
 

--- a/pkg/feed/xml.go
+++ b/pkg/feed/xml.go
@@ -61,6 +61,13 @@ func Build(ctx context.Context, feed *model.Feed, cfg *config.Feed, provider url
 	p.IAuthor = author
 	p.AddSummary(description)
 
+	if cfg.Custom.OwnerName != "" && cfg.Custom.OwnerEmail != "" {
+		p.IOwner = &itunes.Author{
+			Name:  cfg.Custom.OwnerName,
+			Email: cfg.Custom.OwnerEmail,
+		}
+	}
+
 	if cfg.Custom.CoverArt != "" {
 		p.AddImage(cfg.Custom.CoverArt)
 	} else {


### PR DESCRIPTION
Some users were saying their podcasts were getting rejected since `podcast.IOwner` wasn't being set.  This PR adds that functionality to issue #171.

* Did not disturb existing custom Author string, as users may already be using that (wasn't sure on the backwards compatibility with this repo).
* "Name" needed a prefix, since there was already Title and Description.  Picked `Owner` for now.
* Added to existing Unit Test to ensure it gets set when custom config is used.
* Formatted the TOML in the tests to be more pretty.  :-)

NOTE: I do not have a way to test this as I do not use this repo. This is just a drive-by PR to help the authors.