### PR TITLE
dockerfile: source youtube-dl from alpine repos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM alpine:3.10
 
 WORKDIR /app/
-RUN wget -O /usr/bin/youtube-dl https://github.com/ytdl-org/youtube-dl/releases/latest/download/youtube-dl && \
-    chmod +x /usr/bin/youtube-dl && \
-    apk --no-cache add ca-certificates python ffmpeg tzdata
+
+RUN apk --no-cache add ca-certificates python ffmpeg tzdata
+# see #191 for youtube-dl related questions
+RUN apk --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main add youtube-dl 
+
 COPY podsync /app/podsync
 CMD ["/app/podsync"]


### PR DESCRIPTION
Does _not_ close #191, but a temporary solution.

WARN: updating youtube-dl will fail.
```
It looks like you installed youtube-dl with a package manager, pip, setup.py or a tarball. Please use that to update.
```
Instead, to update, use the cmd:
```
apk --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main add youtube-dl
```
I don't know how to do this in go, and if so, the binary needs a switch, if run from docker, indicating that it shall be upgraded via alpine's paman instead.