### PR TITLE
Revert "dockerfile: source youtube-dl from alpine repos"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
 FROM alpine:3.10
 
 WORKDIR /app/
-
-RUN apk --no-cache add ca-certificates python ffmpeg tzdata
-# see #191 for youtube-dl related questions
-RUN apk --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main add youtube-dl 
-
+RUN wget -O /usr/bin/youtube-dl https://github.com/ytdl-org/youtube-dl/releases/latest/download/youtube-dl && \
+    chmod +x /usr/bin/youtube-dl && \
+    apk --no-cache add ca-certificates python ffmpeg tzdata
 COPY podsync /app/podsync
 CMD ["/app/podsync"]


### PR DESCRIPTION
Reverts mxpv/podsync#195
cc #191 

(While currently not implemented, I would argue, in the future, using the alpine's version, and updating via it is preferred. As: often the youtube-dl version in the image is outdated, and you could argue it's better than curl | bash)