### PR TITLE
Dockerfile:add `--no-banner`.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,6 @@ RUN wget -O /usr/bin/youtube-dl https://github.com/ytdl-org/youtube-dl/releases/
     chmod +x /usr/bin/youtube-dl && \
     apk --no-cache add ca-certificates python ffmpeg tzdata
 COPY podsync /app/podsync
-CMD ["/app/podsync"]
+
+ENTRYPOINT ["/app/podsync"]
+CMD ["--no-banner"]


### PR DESCRIPTION
Command output, or `logs` on the docker container results in a garbled banner. Disable printing it for docker.