### PR TITLE
build podsync inside docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
-FROM alpine:3.10
+FROM golang:1.17.5-alpine3.15 AS builder
+WORKDIR /app
+COPY . /app/
+RUN go build -o podsync ./cmd/podsync
 
+FROM alpine:3.10
 WORKDIR /app/
 RUN wget -O /usr/bin/youtube-dl https://github.com/ytdl-org/youtube-dl/releases/latest/download/youtube-dl && \
     chmod +x /usr/bin/youtube-dl && \
     apk --no-cache add ca-certificates python ffmpeg tzdata
-COPY podsync /app/podsync
+COPY --from=builder /app/podsync /app/podsync
 
 ENTRYPOINT ["/app/podsync"]
 CMD ["--no-banner"]

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@ build:
 TAG ?= localhost/podsync
 .PHONY: docker
 docker:
-	GOOS=linux GOARCH=amd64 go build -o podsync ./cmd/podsync
 	docker build -t $(TAG) .
 	docker push $(TAG)
 


### PR DESCRIPTION
Current docker image requires all golang tools to be installed on the host machine.

This change moves the compilation part to the docker image, allowing any machine with docker installed to build podsync