### PR TITLE
fixup: Dockerfile: reinstate location of config.toml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,13 @@
 # See docs for details: https://goreleaser.com/customization/docker/
 
 FROM alpine:3.10
+WORKDIR /app
+
 RUN wget -O /usr/bin/youtube-dl https://github.com/ytdl-org/youtube-dl/releases/latest/download/youtube-dl && \
     chmod +x /usr/bin/youtube-dl && \
     apk --no-cache add ca-certificates python ffmpeg tzdata
-COPY podsync /podsync
+COPY podsync /app/podsync
 
-ENTRYPOINT ["/podsync"]
+
+ENTRYPOINT ["/app/podsync"]
 CMD ["--no-banner"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,4 +9,4 @@ services:
       - 80:80
     volumes:
       - ./data:/data/
-      - ./config.toml:/config.toml
+      - ./config.toml:/app/config.toml


### PR DESCRIPTION
readd `WORKDIR /app`
`config.toml` uses relative path, from the current directory, `$PWD` by default is `/`.

commit f337f6c8b16acad6f6a86648f72061e098652040
removed `WORKDIR /app`, and `/config.toml` was used instead of `/app/config.toml`.
The change was breaking, unexpected and undocumented.
As users already mount `/app/config.toml`, revert to using it.

Closes #270