### PR TITLE
Fix shutdown server context cancel error

### DIFF
--- a/cmd/podsync/main.go
+++ b/cmd/podsync/main.go
@@ -190,8 +190,12 @@ func main() {
 	group.Go(func() error {
 		// Shutdown web server
 		defer func() {
+			ctxShutDown, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer func() {
+				cancel()
+			}()
 			log.Info("shutting down web server")
-			if err := srv.Shutdown(ctx); err != nil {
+			if err := srv.Shutdown(ctxShutDown); err != nil {
 				log.WithError(err).Error("server shutdown failed")
 			}
 		}()


### PR DESCRIPTION
When I used the source code to build the `podsync`, after run the `./podsync` command, I used `ctrl+c` to stop the server, then the log display the `server shutdown failed`, the detailed log displayed below: 

```bash
INFO[2022-02-10T10:50:36+08:00] shutting down web server                     
ERRO[2022-02-10T10:50:36+08:00] server shutdown failed                        error="context canceled"
INFO[2022-02-10T10:50:36+08:00] shutting down cron                           
INFO[2022-02-10T10:50:36+08:00] Got compaction priority: {level:0 score:1.73 dropPrefixes:[]} 
INFO[2022-02-10T10:50:36+08:00] gracefully stopped                           
```
So I fixed this error. And the log displays like this now:

```bash
INFO[2022-02-11T11:32:42+08:00] shutting down web server                     
INFO[2022-02-11T11:32:42+08:00] shutting down cron                           
INFO[2022-02-11T11:32:42+08:00] Got compaction priority: {level:0 score:1.73 dropPrefixes:[]} 
INFO[2022-02-11T11:32:42+08:00] Running for level: 0                         
INFO[2022-02-11T11:32:42+08:00] LOG Compact 0->1, del 1 tables, add 1 tables, took 2.300744ms 
INFO[2022-02-11T11:32:42+08:00] Compaction for level: 0 DONE                 
INFO[2022-02-11T11:32:42+08:00] Force compaction on level 0 done             
INFO[2022-02-11T11:32:42+08:00] gracefully stopped
```