### PR TITLE
Fix cover art quality config and default being ignored

### DIFF
--- a/pkg/builder/youtube.go
+++ b/pkg/builder/youtube.go
@@ -391,14 +391,15 @@ func (yt *YouTubeBuilder) Build(ctx context.Context, cfg *feed.Config) (*model.F
 	}
 
 	feed := &model.Feed{
-		ItemID:       info.ItemID,
-		Provider:     info.Provider,
-		LinkType:     info.LinkType,
-		Format:       cfg.Format,
-		Quality:      cfg.Quality,
-		PageSize:     cfg.PageSize,
-		PlaylistSort: cfg.PlaylistSort,
-		UpdatedAt:    time.Now().UTC(),
+		ItemID:          info.ItemID,
+		Provider:        info.Provider,
+		LinkType:        info.LinkType,
+		Format:          cfg.Format,
+		Quality:         cfg.Quality,
+		CoverArtQuality: cfg.Custom.CoverArtQuality,
+		PageSize:        cfg.PageSize,
+		PlaylistSort:    cfg.PlaylistSort,
+		UpdatedAt:       time.Now().UTC(),
 	}
 
 	if feed.PageSize == 0 {


### PR DESCRIPTION
To actually include the `Custom.CoverArtQuality` field from feed config into the feed query model.

This fixes #197.