### PR TITLE
add support to set feed as private

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -63,6 +63,9 @@ vimeo = [ # Multiple keys will be rotated.
   # Note that setting '--audio-format' for audio format feeds, or '--format' or '--output' for any format may cause
   # unexpected behaviour. You should only use this if you know what you are doing, and have read up on youtube-dl's options!
   youtube_dl_args = ["--write-sub", "--embed-subs", "--sub-lang", "en,en-US,en-GB"]
+  
+  # When set to true, podcasts indexers such as iTunes or Google Podcasts will not index this podcast
+  private_feed = true
 
   # Optional feed customizations
   [feeds.ID1.custom]

--- a/pkg/builder/youtube.go
+++ b/pkg/builder/youtube.go
@@ -399,6 +399,7 @@ func (yt *YouTubeBuilder) Build(ctx context.Context, cfg *feed.Config) (*model.F
 		CoverArtQuality: cfg.Custom.CoverArtQuality,
 		PageSize:        cfg.PageSize,
 		PlaylistSort:    cfg.PlaylistSort,
+		PrivateFeed:     cfg.PrivateFeed,
 		UpdatedAt:       time.Now().UTC(),
 	}
 

--- a/pkg/feed/config.go
+++ b/pkg/feed/config.go
@@ -38,10 +38,10 @@ type Config struct {
 	YouTubeDLArgs []string `toml:"youtube_dl_args"`
 	// Included in OPML file
 	OPML bool `toml:"opml"`
-	// Playlist sort
-	PlaylistSort model.Sorting `toml:"playlist_sort"`
 	// Private feed (not indexed by podcast aggregators)
 	PrivateFeed bool `toml:"private_feed"`
+	// Playlist sort
+	PlaylistSort model.Sorting `toml:"playlist_sort"`
 }
 
 type Filters struct {

--- a/pkg/feed/config.go
+++ b/pkg/feed/config.go
@@ -40,6 +40,8 @@ type Config struct {
 	OPML bool `toml:"opml"`
 	// Playlist sort
 	PlaylistSort model.Sorting `toml:"playlist_sort"`
+	// Private feed (not indexed by podcast aggregators)
+	PrivateFeed bool `toml:"private_feed"`
 }
 
 type Filters struct {

--- a/pkg/feed/xml.go
+++ b/pkg/feed/xml.go
@@ -61,7 +61,7 @@ func Build(_ctx context.Context, feed *model.Feed, cfg *Config, hostname string)
 	p.IAuthor = author
 	p.AddSummary(description)
 
-	if (feed.PrivateFeed) {
+	if feed.PrivateFeed {
 		p.IBlock = "yes"
 	}
 

--- a/pkg/feed/xml.go
+++ b/pkg/feed/xml.go
@@ -61,6 +61,10 @@ func Build(_ctx context.Context, feed *model.Feed, cfg *Config, hostname string)
 	p.IAuthor = author
 	p.AddSummary(description)
 
+	if (feed.PrivateFeed) {
+		p.IBlock = "yes"
+	}
+
 	if cfg.Custom.OwnerName != "" && cfg.Custom.OwnerEmail != "" {
 		p.IOwner = &itunes.Author{
 			Name:  cfg.Custom.OwnerName,

--- a/pkg/model/feed.go
+++ b/pkg/model/feed.go
@@ -63,6 +63,7 @@ type Feed struct {
 	Episodes        []*Episode `json:"-"`        // Array of episodes
 	UpdatedAt       time.Time  `json:"updated_at"`
 	PlaylistSort    Sorting    `json:"playlist_sort"`
+	PrivateFeed     bool       `json:"private_feed"`
 }
 
 type EpisodeStatus string


### PR DESCRIPTION
This fixes #188 

According to https://support.google.com/podcast-publishers/answer/10315648?hl=en&ref_topic=9476061, `<itunes:block>` also prevents feed from being added to Google's aggregator, so `<googleplay:block>` is not neeeded.