### PR TITLE
Fix nil pointer dereference for cron

### DIFF
--- a/cmd/podsync/main.go
+++ b/cmd/podsync/main.go
@@ -138,7 +138,7 @@ func main() {
 	defer close(updates)
 
 	// Create Cron
-	c := cron.New(cron.WithChain(cron.SkipIfStillRunning(nil)))
+	c := cron.New(cron.WithChain(cron.SkipIfStillRunning(cron.DiscardLogger)))
 	m := make(map[string]cron.EntryID)
 
 	// Run updates listener


### PR DESCRIPTION
This fixes #220 and fixes #242.

I did not encounter this myself, but based on the error call stack provided, the error seems to be due to a nil logger being passed to [`cron.SkipIfStillRunning`](https://github.com/robfig/cron/blob/v3.0.1/chain.go#L78).

If the next update occurs before the current update finishes, the nil logger is used without check and triggers the nil pointer dereference error.