### PR TITLE
Fix two regressions introduced by PR #317

### DIFF
--- a/cmd/podsync/main.go
+++ b/cmd/podsync/main.go
@@ -155,6 +155,10 @@ func main() {
 		return
 	}
 
+	// Queue of feeds to update
+	updates := make(chan *feed.Config, 16)
+	defer close(updates)
+
 	group, ctx := errgroup.WithContext(ctx)
 	defer func() {
 		if err := group.Wait(); err != nil && (err != context.Canceled && err != http.ErrServerClosed) {
@@ -162,10 +166,6 @@ func main() {
 		}
 		log.Info("gracefully stopped")
 	}()
-
-	// Queue of feeds to update
-	updates := make(chan *feed.Config, 16)
-	defer close(updates)
 
 	// Create Cron
 	c := cron.New(cron.WithChain(cron.SkipIfStillRunning(cron.DiscardLogger)))

--- a/pkg/fs/local.go
+++ b/pkg/fs/local.go
@@ -13,7 +13,7 @@ import (
 
 // LocalConfig is the storage configuration for local file system
 type LocalConfig struct {
-	DataDir string `yaml:"data_dir"`
+	DataDir string `toml:"data_dir"`
 }
 
 // Local implements local file storage


### PR DESCRIPTION
This fixes #322.

1. The struct tag for config `storage.local.data_dir` was marked as yaml while we are using toml (So GitHub Copilot managed to escape from my check and picked its favorite config file format)
2. Need to make sure that no defer block get executed before the `errgroup.Wait()` block, i.e. the `errgroup.Wait()` block need to be last one in, first one out.

Maybe we need some kind of integration test to catch things like regression 2 in the future?