### PR TITLE
Override the default link

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -95,6 +95,8 @@ vimeo = [ # Multiple keys will be rotated.
   author = "Mrs. Smith (mrs@smith.org)"
   ownerName = "Mrs. Smith"
   ownerEmail = "mrs@smith.org"
+  # optional: this will override the default link (usually the URL address) in the generated RSS feed with another link
+  link = "https://example.org"
 
 # Podsync uses local database to store feeds and episodes metadata.
 # This section is optional and usually not needed to configure unless some very specific corner cases.

--- a/pkg/feed/config.go
+++ b/pkg/feed/config.go
@@ -64,6 +64,7 @@ type Custom struct {
 	Description     string        `toml:"description"`
 	OwnerName       string        `toml:"ownerName"`
 	OwnerEmail      string        `toml:"ownerEmail"`
+	Link            string        `toml:"link"`
 }
 
 type Cleanup struct {

--- a/pkg/feed/xml.go
+++ b/pkg/feed/xml.go
@@ -41,6 +41,7 @@ func Build(_ctx context.Context, feed *model.Feed, cfg *Config, hostname string)
 		author      = feed.Title
 		title       = feed.Title
 		description = feed.Description
+		feedLink    = feed.ItemURL
 	)
 
 	if cfg.Custom.Author != "" {
@@ -55,7 +56,11 @@ func Build(_ctx context.Context, feed *model.Feed, cfg *Config, hostname string)
 		description = cfg.Custom.Description
 	}
 
-	p := itunes.New(title, feed.ItemURL, description, &feed.PubDate, &now)
+	if cfg.Custom.Link != "" {
+		feedLink = cfg.Custom.Link
+	}
+
+	p := itunes.New(title, feedLink, description, &feed.PubDate, &now)
 	p.Generator = podsyncGenerator
 	p.AddSubTitle(title)
 	p.IAuthor = author


### PR DESCRIPTION
This will override the default link (usually the URL address) in the generated RSS feed with another link.

Before:
```
<rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
  <channel>
    <title>Level1News</title>
    <link>https://www.youtube.com/channel/CHANNEL_NAME_TO_HOST</link>
    
    <image>
      <link>https://www.youtube.com/channel/CHANNEL_NAME_TO_HOST</link>
    </image>
```

After:
```
<rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
  <channel>
    <title>Level1News</title>
    <link>https://example.org</link>

    <image>
      <link>https://example.org</link>
    </image>
```

fixes #233