### PR TITLE
Clean up episodes before generating XML feed

### DIFF
--- a/pkg/feed/xml.go
+++ b/pkg/feed/xml.go
@@ -110,7 +110,7 @@ func Build(_ctx context.Context, feed *model.Feed, cfg *Config, hostname string)
 
 	for i, episode := range feed.Episodes {
 		if episode.Status != model.EpisodeDownloaded {
-			// Skip episodes that are not yet downloaded
+			// Skip episodes that are not yet downloaded or have been removed
 			continue
 		}
 

--- a/services/update/updater.go
+++ b/services/update/updater.go
@@ -71,16 +71,16 @@ func (u *Manager) Update(ctx context.Context, feedConfig *feed.Config) error {
 		return errors.Wrap(err, "download failed")
 	}
 
+	if err := u.cleanup(ctx, feedConfig); err != nil {
+		log.WithError(err).Error("cleanup failed")
+	}
+
 	if err := u.buildXML(ctx, feedConfig); err != nil {
 		return errors.Wrap(err, "xml build failed")
 	}
 
 	if err := u.buildOPML(ctx); err != nil {
 		return errors.Wrap(err, "opml build failed")
-	}
-
-	if err := u.cleanup(ctx, feedConfig); err != nil {
-		log.WithError(err).Error("cleanup failed")
 	}
 
 	elapsed := time.Since(started)


### PR DESCRIPTION
Remove the files before updating the XML feed, so that the files deleted in current update do not show up in the XML feed. I eyeballed and made sure that `u.cleanup` does not rely on the state of `u.buildXML` and `u.buildOPML`, but you might want to double check.