### PR TITLE
Re-download the episode if the file is missing

### DIFF
--- a/services/update/updater.go
+++ b/services/update/updater.go
@@ -159,11 +159,19 @@ func (u *Manager) downloadEpisodes(ctx context.Context, feedConfig *feed.Config)
 	if err := u.db.WalkEpisodes(ctx, feedID, func(episode *model.Episode) error {
 		var (
 			logger = log.WithFields(log.Fields{"episode_id": episode.ID})
+			episodeName = feed.EpisodeName(feedConfig, episode)
 		)
+		// Check whether episode already exist in the database
 		if episode.Status != model.EpisodeNew && episode.Status != model.EpisodeError {
-			// File already downloaded
-			logger.Infof("skipping due to already downloaded")
-			return nil
+			// If found in the database, also check if the file exist on the disk
+			_, err := u.fs.Size(ctx, fmt.Sprintf("%s/%s", feedID, episodeName))
+			if err == nil {
+				// File already downloaded
+				logger.WithField("episode_id", episode.ID).Info("skipping due to already downloaded")
+				return nil
+			} else {
+				logger.WithField("episode_id", episode.ID).Warn("unable to find the file on disk for this episode")
+			}
 		}
 
 		if !matchFilters(episode, &feedConfig.Filters) {

--- a/services/update/updater.go
+++ b/services/update/updater.go
@@ -169,9 +169,8 @@ func (u *Manager) downloadEpisodes(ctx context.Context, feedConfig *feed.Config)
 				// File already downloaded
 				logger.WithField("episode_id", episode.ID).Info("skipping due to already downloaded")
 				return nil
-			} else {
-				logger.WithField("episode_id", episode.ID).Warn("unable to find the file on disk for this episode")
 			}
+			logger.WithField("episode_id", episode.ID).Warn("unable to find the file on disk for this episode")
 		}
 
 		if !matchFilters(episode, &feedConfig.Filters) {

--- a/services/update/updater.go
+++ b/services/update/updater.go
@@ -158,7 +158,7 @@ func (u *Manager) downloadEpisodes(ctx context.Context, feedConfig *feed.Config)
 	// Build the list of files to download
 	if err := u.db.WalkEpisodes(ctx, feedID, func(episode *model.Episode) error {
 		var (
-			logger = log.WithFields(log.Fields{"episode_id": episode.ID})
+			logger      = log.WithFields(log.Fields{"episode_id": episode.ID})
 			episodeName = feed.EpisodeName(feedConfig, episode)
 		)
 		// Check whether episode already exist in the database


### PR DESCRIPTION
This PR makes sure that the file exist on disk before considering skipping the download.

It fixes problems where an episode is marked as "already downloaded" in the database but has been deleted on the disk.

The log file will show the following Warning/Debug lines:

```
WARN[2022-11-19T21:43:02+02:00] unable to find the file on disk for this episode  episode_id=iSnLvsfexyz
DEBU[2022-11-19T21:43:02+02:00] adding iSnLvsfexyz ("Some episode name") to queue 
```