### PR TITLE
Fix broken CI Checks step, use Env Vars to build and push Docker Images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.43.0
+          version: v1.50.1
 
       - name: Go mod
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,10 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Prepare Env Vars
+        run: |
+          echo GHCR_USER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
+
       # Publish a new release from git tag.
       - uses: goreleaser/goreleaser-action@v3.2.0
         if: startsWith(github.ref, 'refs/tags/')
@@ -38,13 +42,17 @@ jobs:
           version: latest
           args: release --rm-dist
         env:
+          DOCKERHUB_USER: ${{ secrets.DOCKER_LOGIN }}
+          GHCR_USER: ${{ env.GHCR_USER }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Publish nightly build.
       - uses: goreleaser/goreleaser-action@v3.2.0
-        if: github.event_name == 'schedule'
+        if: ${{ github.repository_owner == 'mxpv' && github.event_name == 'schedule' }}
         with:
           version: latest
           args: release --rm-dist --nightly
         env:
+          DOCKERHUB_USER: ${{ secrets.DOCKER_LOGIN }}
+          GHCR_USER: ${{ env.GHCR_USER }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,11 +21,11 @@ builds:
 
 dockers:
   - image_templates:
-    - 'mxpv/podsync:{{ .Tag }}'
-    - 'mxpv/podsync:v{{ .Major }}.{{ .Minor }}'
-    - 'mxpv/podsync:latest'
-    - 'ghcr.io/mxpv/podsync:{{ .Tag }}'
-    - 'ghcr.io/mxpv/podsync:latest'
+    - "{{ .Env.DOCKERHUB_USER }}/podsync:{{ .Tag }}"
+    - "{{ .Env.DOCKERHUB_USER }}/podsync:v{{ .Major }}.{{ .Minor }}"
+    - "{{ .Env.DOCKERHUB_USER }}/podsync:latest"
+    - "ghcr.io/{{ .Env.GHCR_USER }}/podsync:{{ .Tag }}"
+    - "ghcr.io/{{ .Env.GHCR_USER }}/podsync:latest"
 
 archives:
   - replacements:


### PR DESCRIPTION
This PR contains :
- bump golangci-lint to version v1.50.1 to fix the failed `Check` CI step
- uses Env Vars to build and push Docker Image, so anyone can try to release to their own GHCR/DockerHub repos
- add a condition for the Scheduled builds to only happen from your Git repo, as I assume most people won't want to build nightly builds anyway

PS: The GHCR Repo Name has to be lowercase (see [this error](https://github.com/Th0masL/podsync/actions/runs/3505523564/jobs/5871883670#step:6:63)), but because `github.repository_owner` is case-sensitive (like in my case), it's mandatory to first convert it to lowercase. It's not ideal but that's the only method available so far.