### PR TITLE
WIP - Add support to filter live videos

### DIFF
--- a/cmd/podsync/config_test.go
+++ b/cmd/podsync/config_test.go
@@ -37,7 +37,7 @@ timeout = 15
   update_period = "5h"
   format = "audio"
   quality = "low"
-  filters = { title = "regex for title here", min_duration = 0, max_duration = 86400}
+  filters = { title = "regex for title here", min_duration = 0, max_duration = 86400, is_live = "false" }
   playlist_sort = "desc"
   clean = { keep_last = 10 }
   [feeds.XYZ.custom]
@@ -80,6 +80,7 @@ timeout = 15
 	assert.EqualValues(t, "regex for title here", feed.Filters.Title)
 	assert.EqualValues(t, 0, feed.Filters.MinDuration)
 	assert.EqualValues(t, 86400, feed.Filters.MaxDuration)
+	assert.EqualValues(t, "false", feed.Filters.IsLive)
 	assert.EqualValues(t, 10, feed.Clean.KeepLast)
 	assert.EqualValues(t, model.SortingDesc, feed.PlaylistSort)
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -75,7 +75,7 @@ vimeo = [ # Multiple keys will be rotated.
   # Optional Golang regexp format.
   # If set, then only download matching episodes.
   # Duration filters are in seconds.
-  filters = { title = "regex for title here", not_title = "regex for negative title match", description = "...", not_description = "...", min_duration = 0, max_duration = 86400 }
+  filters = { title = "regex for title here", not_title = "regex for negative title match", description = "...", not_description = "...", min_duration = 0, max_duration = 86400, is_live = "false" }
 
   # Optional extra arguments passed to youtube-dl when downloading videos from this feed.
   # This example would embed available English closed captions in the videos.

--- a/pkg/builder/soundcloud.go
+++ b/pkg/builder/soundcloud.go
@@ -60,6 +60,9 @@ func (s *SoundCloudBuilder) Build(_ctx context.Context, cfg *feed.Config) (*mode
 					trackSize = track.DurationMS * 15 // very rough estimate
 				)
 
+				// For the moment we don't support detecting live videos on SoundCloud
+				var isLive bool = false
+
 				feed.Episodes = append(feed.Episodes, &model.Episode{
 					ID:          videoID,
 					Title:       track.Title,
@@ -70,6 +73,7 @@ func (s *SoundCloudBuilder) Build(_ctx context.Context, cfg *feed.Config) (*mode
 					PubDate:     pubDate,
 					Thumbnail:   track.ArtworkURL,
 					Status:      model.EpisodeNew,
+					IsLive:      isLive,
 				})
 
 				added++

--- a/pkg/builder/vimeo.go
+++ b/pkg/builder/vimeo.go
@@ -135,6 +135,9 @@ func (v *VimeoBuilder) queryVideos(getVideos getVideosFunc, feed *model.Feed) er
 				image    = v.selectImage(video.Pictures, feed.Quality)
 			)
 
+			// For the moment we don't support detecting live videos on Vimeo
+			var isLive bool = false
+
 			feed.Episodes = append(feed.Episodes, &model.Episode{
 				ID:          videoID,
 				Title:       video.Name,
@@ -145,6 +148,7 @@ func (v *VimeoBuilder) queryVideos(getVideos getVideosFunc, feed *model.Feed) er
 				Thumbnail:   image,
 				VideoURL:    videoURL,
 				Status:      model.EpisodeNew,
+				IsLive:      isLive,
 			})
 
 			added++

--- a/pkg/builder/youtube.go
+++ b/pkg/builder/youtube.go
@@ -332,6 +332,12 @@ func (yt *YouTubeBuilder) queryVideoDescriptions(ctx context.Context, playlist m
 				size  = yt.getSize(seconds, feed)
 			)
 
+			// See https://developers.google.com/youtube/v3/docs/videos#snippet.liveBroadcastContent
+			var isLive bool = false
+			if snippet.LiveBroadcastContent != "none" {
+				isLive = true
+			}
+
 			feed.Episodes = append(feed.Episodes, &model.Episode{
 				ID:          video.Id,
 				Title:       snippet.Title,
@@ -343,6 +349,7 @@ func (yt *YouTubeBuilder) queryVideoDescriptions(ctx context.Context, playlist m
 				PubDate:     pubDate,
 				Order:       order,
 				Status:      model.EpisodeNew,
+				IsLive:      isLive,
 			})
 		}
 	}

--- a/pkg/feed/config.go
+++ b/pkg/feed/config.go
@@ -58,6 +58,7 @@ type Filters struct {
 	NotDescription string `toml:"not_description"`
 	MinDuration    int64  `toml:"min_duration"`
 	MaxDuration    int64  `toml:"max_duration"`
+	IsLive         string `toml:"is_live"`
 	// More filters to be added here
 }
 

--- a/pkg/model/feed.go
+++ b/pkg/model/feed.go
@@ -41,6 +41,7 @@ type Episode struct {
 	Size        int64         `json:"size"`
 	Order       string        `json:"order"`
 	Status      EpisodeStatus `json:"status"` // Disk status
+	IsLive      bool          `json:"is_live"`
 }
 
 type Feed struct {


### PR DESCRIPTION
This PR add a nicer way to filter out Live videos on YouTube, instead of having to edit the `youtube-dl` parameters as suggested [here](https://github.com/mxpv/podsync/issues/437).

I've not been able to investigate how to deal with Live videos on Vimeo/Soundcloud, so for the moment the behavior will remain unchanged for those 2 sites.

Question: Since I'm assuming nobody wants to download partial Live videos, and I think it's not even working to download Live videos, should we set the default behavior to ignore the Live videos ? That would mean that if the user does not configure the filter `is_live`, the live videos will be ignored by default.

