### PR TITLE
Add option to enable debug mode in config.toml

### DIFF
--- a/cmd/podsync/config.go
+++ b/cmd/podsync/config.go
@@ -48,6 +48,8 @@ type Log struct {
 	MaxAge int `toml:"max_age"`
 	// Compress old backups
 	Compress bool `toml:"compress"`
+	// Debug mode
+	Debug bool `toml:"debug"`
 }
 
 // LoadConfig loads TOML configuration from a file path

--- a/cmd/podsync/main.go
+++ b/cmd/podsync/main.go
@@ -92,6 +92,11 @@ func main() {
 			MaxAge:     cfg.Log.MaxAge,
 			Compress:   cfg.Log.Compress,
 		})
+
+		// Optionally enable debug mode from config.toml
+		if cfg.Log.Debug {
+			log.SetLevel(log.DebugLevel)
+		}
 	}
 
 	log.WithFields(log.Fields{

--- a/config.toml.example
+++ b/config.toml.example
@@ -82,7 +82,7 @@ vimeo = [ # Multiple keys will be rotated.
   # Note that setting '--audio-format' for audio format feeds, or '--format' or '--output' for any format may cause
   # unexpected behaviour. You should only use this if you know what you are doing, and have read up on youtube-dl's options!
   youtube_dl_args = ["--write-sub", "--embed-subs", "--sub-lang", "en,en-US,en-GB"]
-  
+
   # When set to true, podcasts indexers such as iTunes or Google Podcasts will not index this podcast
   private_feed = true
 
@@ -123,3 +123,4 @@ max_size = 50 # MB
 max_age = 30 # days
 max_backups = 7
 compress = true
+debug = false


### PR DESCRIPTION
Allow to enable debug mode by setting the value of `debug = true` in `config.toml > log`