### PR TITLE
Enforce using a lowercase value for Image Name

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,7 +9,6 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   publish:
@@ -27,6 +26,12 @@ jobs:
 
       - name: 🧪 Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+
+      # The Docker Image Name need to be lowercase https://github.com/orgs/community/discussions/25768
+      - name: 🧪 Convert the GitHub Repository name to lowercase, and use it as image name
+        run: echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> ${GITHUB_ENV}
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
 
       - name: 🔒 Log in to the Container registry
         uses: docker/login-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   publish:
@@ -27,6 +26,12 @@ jobs:
 
       - name: 🧪 Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+
+      # The Docker Image Name need to be lowercase https://github.com/orgs/community/discussions/25768
+      - name: 🧪 Convert the GitHub Repository name to lowercase, and use it as image name
+        run: echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> ${GITHUB_ENV}
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
 
       - name: 🔒 Log in to the Container registry
         uses: docker/login-action@v2


### PR DESCRIPTION
It seems like `ghcr.io` does not support uppercase in the image name.

Since the current CI workflow use the value of `${{ github.repository }}`, anyone that has at least one uppercase letter in their username (like me) will fail to push to `ghcr.io` with the following error:

```
Error: buildx failed with: ERROR: invalid tag "ghcr.io/Th0masL/podsync:latest": repository name must be lowercase
```
See error here : https://github.com/Th0masL/podsync/actions/runs/5499113405/jobs/10021072765#step:5:116

More explanations here : https://github.com/orgs/community/discussions/25768