### PR TITLE
Add TLS support

### DIFF
--- a/cmd/podsync/main.go
+++ b/cmd/podsync/main.go
@@ -237,7 +237,11 @@ func main() {
 
 	group.Go(func() error {
 		log.Infof("running listener at %s", srv.Addr)
-		return srv.ListenAndServe()
+		if cfg.Server.TLS {
+			return srv.ListenAndServeTLS(cfg.Server.CertificatePath, cfg.Server.KeyFilePath)
+		} else {
+			return srv.ListenAndServe()
+		}
 	})
 
 	group.Go(func() error {

--- a/config.toml.example
+++ b/config.toml.example
@@ -11,6 +11,10 @@ hostname = "https://my.test.host:4443"
 bind_address = "172.20.10.2"
 # Specify path for reverse proxy and only [A-Za-z0-9]
 path = "test"
+# Optional. If you want to use TLS you must set the TLS flag and path to the certificate file and private key file.
+tls = true
+certificate_path = "/var/www/cert.pem"  
+key_file_path = "/var/www/priv.pem"
 
 # Configure where to store the episode data
 [storage]

--- a/services/web/server.go
+++ b/services/web/server.go
@@ -20,6 +20,12 @@ type Config struct {
 	// "*": bind all IP addresses which is default option
 	// localhost or 127.0.0.1  bind a single IPv4 address
 	BindAddress string `toml:"bind_address"`
+	// Flag indicating if the server will use TLS
+	TLS bool `toml:"tls"`
+	// Path to a certificate file for TLS connections
+	CertificatePath string `toml:"certificate_path"`
+	// Path to a private key file for TLS connections
+	KeyFilePath string `toml:"key_file_path"`
 	// Specify path for reverse proxy and only [A-Za-z0-9]
 	Path string `toml:"path"`
 	// DataDir is a path to a directory to keep XML feeds and downloaded episodes,


### PR DESCRIPTION
I added three new fields to the Server configuration in order to enable TLS connections. I made sure this was backwards compatible so it won't break any existing configuration files. 

- **tls** - Flag that indicates the server should listen for TLS connections
- **certificate_path** - Full path to the certificate file
- **key_file_path** - Full path to the private key file