### PR TITLE
fix warning: Variable 'feed' collides with imported package name

### DIFF
--- a/cmd/podsync/config.go
+++ b/cmd/podsync/config.go
@@ -155,29 +155,29 @@ func (c *Config) applyDefaults(configPath string) {
 		c.Database.Dir = filepath.Join(filepath.Dir(configPath), "db")
 	}
 
-	for _, feed := range c.Feeds {
-		if feed.UpdatePeriod == 0 {
-			feed.UpdatePeriod = model.DefaultUpdatePeriod
+	for _, _feed := range c.Feeds {
+		if _feed.UpdatePeriod == 0 {
+			_feed.UpdatePeriod = model.DefaultUpdatePeriod
 		}
 
-		if feed.Quality == "" {
-			feed.Quality = model.DefaultQuality
+		if _feed.Quality == "" {
+			_feed.Quality = model.DefaultQuality
 		}
 
-		if feed.Custom.CoverArtQuality == "" {
-			feed.Custom.CoverArtQuality = model.DefaultQuality
+		if _feed.Custom.CoverArtQuality == "" {
+			_feed.Custom.CoverArtQuality = model.DefaultQuality
 		}
 
-		if feed.Format == "" {
-			feed.Format = model.DefaultFormat
+		if _feed.Format == "" {
+			_feed.Format = model.DefaultFormat
 		}
 
-		if feed.PageSize == 0 {
-			feed.PageSize = model.DefaultPageSize
+		if _feed.PageSize == 0 {
+			_feed.PageSize = model.DefaultPageSize
 		}
 
-		if feed.PlaylistSort == "" {
-			feed.PlaylistSort = model.SortingAsc
+		if _feed.PlaylistSort == "" {
+			_feed.PlaylistSort = model.SortingAsc
 		}
 	}
 }

--- a/pkg/builder/soundcloud.go
+++ b/pkg/builder/soundcloud.go
@@ -22,7 +22,7 @@ func (s *SoundCloudBuilder) Build(_ctx context.Context, cfg *feed.Config) (*mode
 		return nil, err
 	}
 
-	feed := &model.Feed{
+	_feed := &model.Feed{
 		ItemID:    info.ItemID,
 		Provider:  info.Provider,
 		LinkType:  info.LinkType,
@@ -39,16 +39,16 @@ func (s *SoundCloudBuilder) Build(_ctx context.Context, cfg *feed.Config) (*mode
 				return nil, err
 			}
 
-			feed.Title = scplaylist.Title
-			feed.Description = scplaylist.Description
-			feed.ItemURL = cfg.URL
+			_feed.Title = scplaylist.Title
+			_feed.Description = scplaylist.Description
+			_feed.ItemURL = cfg.URL
 
 			date, err := time.Parse(time.RFC3339, scplaylist.CreatedAt)
 			if err == nil {
-				feed.PubDate = date
+				_feed.PubDate = date
 			}
-			feed.Author = scplaylist.User.Username
-			feed.CoverArt = scplaylist.ArtworkURL
+			_feed.Author = scplaylist.User.Username
+			_feed.CoverArt = scplaylist.ArtworkURL
 
 			var added = 0
 			for _, track := range scplaylist.Tracks {
@@ -60,7 +60,7 @@ func (s *SoundCloudBuilder) Build(_ctx context.Context, cfg *feed.Config) (*mode
 					trackSize = track.DurationMS * 15 // very rough estimate
 				)
 
-				feed.Episodes = append(feed.Episodes, &model.Episode{
+				_feed.Episodes = append(_feed.Episodes, &model.Episode{
 					ID:          videoID,
 					Title:       track.Title,
 					Description: track.Description,
@@ -74,12 +74,12 @@ func (s *SoundCloudBuilder) Build(_ctx context.Context, cfg *feed.Config) (*mode
 
 				added++
 
-				if added >= feed.PageSize {
-					return feed, nil
+				if added >= _feed.PageSize {
+					return _feed, nil
 				}
 			}
 
-			return feed, nil
+			return _feed, nil
 		}
 	}
 

--- a/pkg/builder/soundcloud_test.go
+++ b/pkg/builder/soundcloud_test.go
@@ -19,17 +19,17 @@ func TestSoundCloud_BuildFeed(t *testing.T) {
 
 	for _, addr := range urls {
 		t.Run(addr, func(t *testing.T) {
-			feed, err := builder.Build(testCtx, &feed.Config{URL: addr})
+			_feed, err := builder.Build(testCtx, &feed.Config{URL: addr})
 			require.NoError(t, err)
 
-			assert.NotEmpty(t, feed.Title)
-			assert.NotEmpty(t, feed.Description)
-			assert.NotEmpty(t, feed.Author)
-			assert.NotEmpty(t, feed.ItemURL)
+			assert.NotEmpty(t, _feed.Title)
+			assert.NotEmpty(t, _feed.Description)
+			assert.NotEmpty(t, _feed.Author)
+			assert.NotEmpty(t, _feed.ItemURL)
 
-			assert.NotZero(t, len(feed.Episodes))
+			assert.NotZero(t, len(_feed.Episodes))
 
-			for _, item := range feed.Episodes {
+			for _, item := range _feed.Episodes {
 				assert.NotEmpty(t, item.Title)
 				assert.NotEmpty(t, item.VideoURL)
 				assert.NotZero(t, item.Duration)

--- a/pkg/builder/vimeo.go
+++ b/pkg/builder/vimeo.go
@@ -164,7 +164,7 @@ func (v *VimeoBuilder) Build(ctx context.Context, cfg *feed.Config) (*model.Feed
 		return nil, err
 	}
 
-	feed := &model.Feed{
+	_feed := &model.Feed{
 		ItemID:    info.ItemID,
 		Provider:  info.Provider,
 		LinkType:  info.LinkType,
@@ -175,39 +175,39 @@ func (v *VimeoBuilder) Build(ctx context.Context, cfg *feed.Config) (*model.Feed
 	}
 
 	if info.LinkType == model.TypeChannel {
-		if err := v.queryChannel(feed); err != nil {
+		if err := v.queryChannel(_feed); err != nil {
 			return nil, err
 		}
 
-		if err := v.queryVideos(v.client.Channels.ListVideo, feed); err != nil {
+		if err := v.queryVideos(v.client.Channels.ListVideo, _feed); err != nil {
 			return nil, err
 		}
 
-		return feed, nil
+		return _feed, nil
 	}
 
 	if info.LinkType == model.TypeGroup {
-		if err := v.queryGroup(feed); err != nil {
+		if err := v.queryGroup(_feed); err != nil {
 			return nil, err
 		}
 
-		if err := v.queryVideos(v.client.Groups.ListVideo, feed); err != nil {
+		if err := v.queryVideos(v.client.Groups.ListVideo, _feed); err != nil {
 			return nil, err
 		}
 
-		return feed, nil
+		return _feed, nil
 	}
 
 	if info.LinkType == model.TypeUser {
-		if err := v.queryUser(feed); err != nil {
+		if err := v.queryUser(_feed); err != nil {
 			return nil, err
 		}
 
-		if err := v.queryVideos(v.client.Users.ListVideo, feed); err != nil {
+		if err := v.queryVideos(v.client.Users.ListVideo, _feed); err != nil {
 			return nil, err
 		}
 
-		return feed, nil
+		return _feed, nil
 	}
 
 	return nil, errors.New("unsupported feed type")

--- a/pkg/builder/youtube.go
+++ b/pkg/builder/youtube.go
@@ -410,7 +410,7 @@ func (yt *YouTubeBuilder) Build(ctx context.Context, cfg *feed.Config) (*model.F
 		return nil, err
 	}
 
-	feed := &model.Feed{
+	_feed := &model.Feed{
 		ItemID:          info.ItemID,
 		Provider:        info.Provider,
 		LinkType:        info.LinkType,
@@ -423,32 +423,32 @@ func (yt *YouTubeBuilder) Build(ctx context.Context, cfg *feed.Config) (*model.F
 		UpdatedAt:       time.Now().UTC(),
 	}
 
-	if feed.PageSize == 0 {
-		feed.PageSize = maxYoutubeResults
+	if _feed.PageSize == 0 {
+		_feed.PageSize = maxYoutubeResults
 	}
 
 	// Query general information about feed (title, description, lang, etc)
-	if err := yt.queryFeed(ctx, feed, &info); err != nil {
+	if err := yt.queryFeed(ctx, _feed, &info); err != nil {
 		return nil, err
 	}
 
-	if err := yt.queryItems(ctx, feed); err != nil {
+	if err := yt.queryItems(ctx, _feed); err != nil {
 		return nil, err
 	}
 
 	// YT API client gets 50 episodes per query.
 	// Round up to page size.
-	if len(feed.Episodes) > feed.PageSize {
-		feed.Episodes = feed.Episodes[:feed.PageSize]
+	if len(_feed.Episodes) > _feed.PageSize {
+		_feed.Episodes = _feed.Episodes[:_feed.PageSize]
 	}
 
-	sort.Slice(feed.Episodes, func(i, j int) bool {
-		item1, _ := strconv.Atoi(feed.Episodes[i].Order)
-		item2, _ := strconv.Atoi(feed.Episodes[j].Order)
+	sort.Slice(_feed.Episodes, func(i, j int) bool {
+		item1, _ := strconv.Atoi(_feed.Episodes[i].Order)
+		item2, _ := strconv.Atoi(_feed.Episodes[j].Order)
 		return item1 < item2
 	})
 
-	return feed, nil
+	return _feed, nil
 }
 
 func NewYouTubeBuilder(key string) (*YouTubeBuilder, error) {

--- a/pkg/builder/youtube_test.go
+++ b/pkg/builder/youtube_test.go
@@ -52,17 +52,17 @@ func TestYT_BuildFeed(t *testing.T) {
 
 	for _, addr := range urls {
 		t.Run(addr, func(t *testing.T) {
-			feed, err := builder.Build(testCtx, &feed.Config{URL: addr})
+			_feed, err := builder.Build(testCtx, &feed.Config{URL: addr})
 			require.NoError(t, err)
 
-			assert.NotEmpty(t, feed.Title)
-			assert.NotEmpty(t, feed.Description)
-			assert.NotEmpty(t, feed.Author)
-			assert.NotEmpty(t, feed.ItemURL)
+			assert.NotEmpty(t, _feed.Title)
+			assert.NotEmpty(t, _feed.Description)
+			assert.NotEmpty(t, _feed.Author)
+			assert.NotEmpty(t, _feed.ItemURL)
 
-			assert.NotZero(t, len(feed.Episodes))
+			assert.NotZero(t, len(_feed.Episodes))
 
-			for _, item := range feed.Episodes {
+			for _, item := range _feed.Episodes {
 				assert.NotEmpty(t, item.Title)
 				assert.NotEmpty(t, item.VideoURL)
 				assert.NotZero(t, item.Duration)
@@ -91,10 +91,10 @@ func TestYT_GetVideoCount(t *testing.T) {
 		{Provider: model.ProviderYoutube, LinkType: model.TypePlaylist, ItemID: "PLUVl5pafUrBydT_gsCjRGeCy0hFHloec8"},
 	}
 
-	for _, f := range feeds {
-		feed := f
-		t.Run(f.ItemID, func(t *testing.T) {
-			count, err := builder.GetVideoCount(testCtx, feed)
+	for _, _feed := range feeds {
+		feedCopy := _feed
+		t.Run(_feed.ItemID, func(t *testing.T) {
+			count, err := builder.GetVideoCount(testCtx, feedCopy)
 			assert.NoError(t, err)
 			assert.NotZero(t, count)
 		})


### PR DESCRIPTION
After using podsync for a long time, I want to make some support to this awesome project to show my thanks.
As my first pull request, I just want to make some minor warning fix.

Variable `feed` collides with imported package name, so I rename `feed` to `_feed`, and before that, I rename `_feed` to another name, such as `cronFeed` in `cmd/podsync/main.go`, `feedCopy` in `pkg/builder/youtube_test.go`