### PR TITLE
skip unreleased premiere videos

### DIFF
--- a/pkg/builder/youtube.go
+++ b/pkg/builder/youtube.go
@@ -301,6 +301,11 @@ func (yt *YouTubeBuilder) queryVideoDescriptions(ctx context.Context, playlist m
 				image    = yt.selectThumbnail(snippet.Thumbnails, feed.Quality, videoID)
 			)
 
+			// Skip unreleased Premiere videos
+			if snippet.LiveBroadcastContent == "upcoming" {
+				continue
+			}
+
 			// Parse date added to playlist / publication date
 			dateStr := ""
 			playlistItem, ok := playlist[video.Id]

--- a/pkg/builder/youtube.go
+++ b/pkg/builder/youtube.go
@@ -301,8 +301,8 @@ func (yt *YouTubeBuilder) queryVideoDescriptions(ctx context.Context, playlist m
 				image    = yt.selectThumbnail(snippet.Thumbnails, feed.Quality, videoID)
 			)
 
-			// Skip unreleased Premiere videos
-			if snippet.LiveBroadcastContent == "upcoming" {
+			// Skip unreleased/airing Premiere videos
+			if snippet.LiveBroadcastContent == "upcoming" || snippet.LiveBroadcastContent == "live" {
 				continue
 			}
 


### PR DESCRIPTION
I encountered the same issue as #638, so took a look at the unclosed PR #639. Here's my attempt to cleanly resolve the problem. it still skips adding it to the queue, but instead of checking `ContentDetails`, check the correct field to determine whether it is a premiere video.