### PR TITLE
Include database directory in docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ $ docker pull ghcr.io/mxpv/podsync:latest
 $ docker run \
     -p 8080:8080 \
     -v $(pwd)/data:/app/data/ \
+    -v $(pwd)/db:/app/db/ \
     -v $(pwd)/config.toml:/app/config.toml \
     ghcr.io/mxpv/podsync:latest
 ```
@@ -146,6 +147,7 @@ services:
     container_name: podsync
     volumes:
       - ./data:/app/data/
+      - ./db:/app/db/
       - ./config.toml:/app/config.toml
     ports:
       - 8080:8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,4 +9,5 @@ services:
       - 80:80
     volumes:
       - ./data:/app/data/
+      - ./db:/app/db/
       - ./config.toml:/app/config.toml


### PR DESCRIPTION
The database should probably be mapped outside the container. (I think it also helps when you want to run the container as a non-root user as /app isn't writable by non-root users I think)