### PR TITLE
Set API keys through environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ port = 8080
   data_dir = "/app/data/"
 
 [tokens]
-youtube = "PASTE YOUR API KEY HERE"
+youtube = "PASTE YOUR API KEY HERE" # See config.toml.example for environment variables
 
 [feeds]
     [feeds.ID1]

--- a/cmd/podsync/config.go
+++ b/cmd/podsync/config.go
@@ -193,10 +193,10 @@ func (c *Config) applyDefaults(configPath string) {
 
 func (c *Config) applyEnv() {
 	envVars := map[model.Provider]string{
-		model.ProviderYoutube:    "YOUTUBE_API_KEY",
-		model.ProviderVimeo:      "VIMEO_API_KEY",
-		model.ProviderSoundcloud: "SOUNDCLOUD_API_KEY",
-		model.ProviderTwitch:     "TWITCH_API_KEY",
+		model.ProviderYoutube:    "PODSYNC_YOUTUBE_API_KEY",
+		model.ProviderVimeo:      "PODSYNC_VIMEO_API_KEY",
+		model.ProviderSoundcloud: "PODSYNC_SOUNDCLOUD_API_KEY",
+		model.ProviderTwitch:     "PODSYNC_TWITCH_API_KEY",
 	}
 
 	// Replace API keys from config with environment variables

--- a/cmd/podsync/config_test.go
+++ b/cmd/podsync/config_test.go
@@ -360,8 +360,8 @@ data_dir = "/data"
 		defer os.Remove(path)
 
 		// Set environment variables
-		t.Setenv("YOUTUBE_API_KEY", "env_youtube_key")
-		t.Setenv("VIMEO_API_KEY", "env_vimeo_key")
+		t.Setenv("PODSYNC_YOUTUBE_API_KEY", "env_youtube_key")
+		t.Setenv("PODSYNC_VIMEO_API_KEY", "env_vimeo_key")
 
 		config, err := LoadConfig(path)
 		assert.NoError(t, err)
@@ -388,7 +388,7 @@ data_dir = "/data"
 		defer os.Remove(path)
 
 		// Set environment variable with multiple keys
-		t.Setenv("YOUTUBE_API_KEY", "key1 key2 key3")
+		t.Setenv("PODSYNC_YOUTUBE_API_KEY", "key1 key2 key3")
 
 		config, err := LoadConfig(path)
 		assert.NoError(t, err)

--- a/cmd/podsync/main.go
+++ b/cmd/podsync/main.go
@@ -135,6 +135,26 @@ func main() {
 		log.WithError(err).Fatal("failed to open storage")
 	}
 
+	environmentVariableMap := map[model.Provider]string{
+		model.ProviderYoutube:    "YOUTUBE_API_KEY",
+		model.ProviderVimeo:      "VIMEO_API_KEY",
+		model.ProviderSoundcloud: "SOUNDCLOUD_API_KEY",
+		model.ProviderTwitch:     "TWITCH_API_KEY",
+	}
+
+	// Replace API keys from config with environment variables
+	for provider, environmentVariable := range environmentVariableMap {
+		val, ok := os.LookupEnv(environmentVariable)
+		if ok {
+			log.Infof("Found %s environment variable, replacing config token with it", environmentVariable)
+			// If no tokens are provided in the config.toml, we need to create a new map
+			if cfg.Tokens == nil {
+				cfg.Tokens = make(map[model.Provider]StringSlice)
+			}
+			cfg.Tokens[provider] = []string{val}
+		}
+	}
+
 	// Run updater thread
 	log.Debug("creating key providers")
 	keys := map[model.Provider]feed.KeyProvider{}

--- a/cmd/podsync/main.go
+++ b/cmd/podsync/main.go
@@ -135,26 +135,6 @@ func main() {
 		log.WithError(err).Fatal("failed to open storage")
 	}
 
-	environmentVariableMap := map[model.Provider]string{
-		model.ProviderYoutube:    "YOUTUBE_API_KEY",
-		model.ProviderVimeo:      "VIMEO_API_KEY",
-		model.ProviderSoundcloud: "SOUNDCLOUD_API_KEY",
-		model.ProviderTwitch:     "TWITCH_API_KEY",
-	}
-
-	// Replace API keys from config with environment variables
-	for provider, environmentVariable := range environmentVariableMap {
-		val, ok := os.LookupEnv(environmentVariable)
-		if ok {
-			log.Infof("Found %s environment variable, replacing config token with it", environmentVariable)
-			// If no tokens are provided in the config.toml, we need to create a new map
-			if cfg.Tokens == nil {
-				cfg.Tokens = make(map[model.Provider]StringSlice)
-			}
-			cfg.Tokens[provider] = []string{val}
-		}
-	}
-
 	// Run updater thread
 	log.Debug("creating key providers")
 	keys := map[model.Provider]feed.KeyProvider{}

--- a/config.toml.example
+++ b/config.toml.example
@@ -49,6 +49,8 @@ key_file_path = "/var/www/priv.pem"
 #   VIMEO_API_KEY for Vimeo
 #   SOUNDCLOUD_API_KEY for Soundcloud
 #   TWITCH_API_KEY for Twitch (format: CLIENT_ID:CLIENT_SECRET)
+# Environment variables support multiple keys separated by spaces for API key rotation:
+#   export YOUTUBE_API_KEY="key1 key2 key3"
 [tokens]
 youtube = "YOUTUBE_API_TOKEN" # YouTube API Key. See https://developers.google.com/youtube/registering_an_application
 vimeo = [ # Multiple keys will be rotated.

--- a/config.toml.example
+++ b/config.toml.example
@@ -45,12 +45,12 @@ key_file_path = "/var/www/priv.pem"
 # API keys to be used to access Youtube and Vimeo.
 # These can be either specified as string parameter or array of string (so those will be rotated).
 # Alternatively, you can set the following environment variables:
-#   YOUTUBE_API_KEY for YouTube
-#   VIMEO_API_KEY for Vimeo
-#   SOUNDCLOUD_API_KEY for Soundcloud
-#   TWITCH_API_KEY for Twitch (format: CLIENT_ID:CLIENT_SECRET)
+#   PODSYNC_YOUTUBE_API_KEY for YouTube
+#   PODSYNC_VIMEO_API_KEY for Vimeo
+#   PODSYNC_SOUNDCLOUD_API_KEY for Soundcloud
+#   PODSYNC_TWITCH_API_KEY for Twitch (format: CLIENT_ID:CLIENT_SECRET)
 # Environment variables support multiple keys separated by spaces for API key rotation:
-#   export YOUTUBE_API_KEY="key1 key2 key3"
+#   export PODSYNC_YOUTUBE_API_KEY="key1 key2 key3"
 [tokens]
 youtube = "YOUTUBE_API_TOKEN" # YouTube API Key. See https://developers.google.com/youtube/registering_an_application
 vimeo = [ # Multiple keys will be rotated.

--- a/config.toml.example
+++ b/config.toml.example
@@ -44,6 +44,11 @@ key_file_path = "/var/www/priv.pem"
 
 # API keys to be used to access Youtube and Vimeo.
 # These can be either specified as string parameter or array of string (so those will be rotated).
+# Alternatively, you can set the following environment variables:
+#   YOUTUBE_API_KEY for YouTube
+#   VIMEO_API_KEY for Vimeo
+#   SOUNDCLOUD_API_KEY for Soundcloud
+#   TWITCH_API_KEY for Twitch (format: CLIENT_ID:CLIENT_SECRET)
 [tokens]
 youtube = "YOUTUBE_API_TOKEN" # YouTube API Key. See https://developers.google.com/youtube/registering_an_application
 vimeo = [ # Multiple keys will be rotated.

--- a/docs/how_to_get_vimeo_token.md
+++ b/docs/how_to_get_vimeo_token.md
@@ -16,10 +16,10 @@ vimeo = "ecd4d34b07bcb9509ABCD"
 ```
 Or set the environment variable:
 ```sh
-export VIMEO_API_KEY="ecd4d34b07bcb9509ABCD"
+export PODSYNC_VIMEO_API_KEY="ecd4d34b07bcb9509ABCD"
 ```
 
 For API key rotation, you can specify multiple keys separated by spaces:
 ```sh
-export VIMEO_API_KEY="ecd4d34b07bcb9509ABCD fdc5e45c18cda0610EFGH"
+export PODSYNC_VIMEO_API_KEY="ecd4d34b07bcb9509ABCD fdc5e45c18cda0610EFGH"
 ```

--- a/docs/how_to_get_vimeo_token.md
+++ b/docs/how_to_get_vimeo_token.md
@@ -18,3 +18,8 @@ Or set the environment variable:
 ```sh
 export VIMEO_API_KEY="ecd4d34b07bcb9509ABCD"
 ```
+
+For API key rotation, you can specify multiple keys separated by spaces:
+```sh
+export VIMEO_API_KEY="ecd4d34b07bcb9509ABCD fdc5e45c18cda0610EFGH"
+```

--- a/docs/how_to_get_vimeo_token.md
+++ b/docs/how_to_get_vimeo_token.md
@@ -9,8 +9,12 @@
 ![Generate an access token](img/vimeo_access_token.png)
 6. Click `Generate`.
 ![Tokens](img/vimeo_token.png)
-7. Copy a token to your CLI's configuration file.
+7. Copy a token to your CLI's configuration file or set it as an environment variable.
 ```toml
 [tokens]
 vimeo = "ecd4d34b07bcb9509ABCD"
+```
+Or set the environment variable:
+```sh
+export VIMEO_API_KEY="ecd4d34b07bcb9509ABCD"
 ```

--- a/docs/how_to_get_youtube_api_key.md
+++ b/docs/how_to_get_youtube_api_key.md
@@ -15,9 +15,13 @@
 6. Click `Create credentials`.
 7. Select `API key`.
 ![Create API key](img/youtube_create_api_key.png)
-8. Copy token to your CLI's configuration file.
+8. Copy token to your CLI's configuration file or set it as an environment variable:
 ![Copy token](img/youtube_copy_token.png)
 ```toml
 [tokens]
 youtube = "AIzaSyD4w2s-k79YNR98ABC"
+```
+Or set the environment variable:
+```sh
+export YOUTUBE_API_KEY="AIzaSyD4w2s-k79YNR98ABC"
 ```

--- a/docs/how_to_get_youtube_api_key.md
+++ b/docs/how_to_get_youtube_api_key.md
@@ -25,3 +25,8 @@ Or set the environment variable:
 ```sh
 export YOUTUBE_API_KEY="AIzaSyD4w2s-k79YNR98ABC"
 ```
+
+For API key rotation, you can specify multiple keys separated by spaces:
+```sh
+export YOUTUBE_API_KEY="AIzaSyD4w2s-k79YNR98ABC AIzaSyD4w2s-k79YNR98DEF"
+```

--- a/docs/how_to_get_youtube_api_key.md
+++ b/docs/how_to_get_youtube_api_key.md
@@ -23,10 +23,10 @@ youtube = "AIzaSyD4w2s-k79YNR98ABC"
 ```
 Or set the environment variable:
 ```sh
-export YOUTUBE_API_KEY="AIzaSyD4w2s-k79YNR98ABC"
+export PODSYNC_YOUTUBE_API_KEY="AIzaSyD4w2s-k79YNR98ABC"
 ```
 
 For API key rotation, you can specify multiple keys separated by spaces:
 ```sh
-export YOUTUBE_API_KEY="AIzaSyD4w2s-k79YNR98ABC AIzaSyD4w2s-k79YNR98DEF"
+export PODSYNC_YOUTUBE_API_KEY="AIzaSyD4w2s-k79YNR98ABC AIzaSyD4w2s-k79YNR98DEF"
 ```


### PR DESCRIPTION
Allows users to set API keys through environment variables. This would be helpful to allow checking in config files to git or to simply provide more flexibility.

Closes #504
Closes #225 