### PR TITLE
Add YouTube handle support

### DIFF
--- a/pkg/builder/soundcloud_test.go
+++ b/pkg/builder/soundcloud_test.go
@@ -1,12 +1,15 @@
 package builder
 
 import (
+	"context"
 	"testing"
 
 	"github.com/mxpv/podsync/pkg/feed"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+var testCtx = context.Background()
 
 func TestSoundCloud_BuildFeed(t *testing.T) {
 	builder, err := NewSoundcloudBuilder()

--- a/pkg/builder/url.go
+++ b/pkg/builder/url.go
@@ -135,6 +135,30 @@ func parseYoutubeURL(parsed *url.URL) (model.Type, string, error) {
 		return kind, id, nil
 	}
 
+	// - https://www.youtube.com/@username
+	// - https://www.youtube.com/@username/videos
+	if strings.HasPrefix(path, "/@") {
+		kind := model.TypeHandle
+
+		parts := strings.Split(parsed.EscapedPath(), "/")
+		if len(parts) <= 1 {
+			return "", "", errors.New("invalid handle link")
+		}
+
+		handle := parts[1]
+		if handle == "" || !strings.HasPrefix(handle, "@") {
+			return "", "", errors.New("invalid handle format")
+		}
+
+		// Remove the @ prefix for storage
+		id := strings.TrimPrefix(handle, "@")
+		if id == "" {
+			return "", "", errors.New("empty handle")
+		}
+
+		return kind, id, nil
+	}
+
 	return "", "", errors.New("unsupported link format")
 }
 

--- a/pkg/builder/url_test.go
+++ b/pkg/builder/url_test.go
@@ -45,12 +45,49 @@ func TestParseYoutubeURL_User(t *testing.T) {
 	require.Equal(t, "fxigr1", id)
 }
 
+func TestParseYoutubeURL_Handle(t *testing.T) {
+	// Test basic handle URL
+	link, _ := url.ParseRequestURI("https://www.youtube.com/@username")
+	kind, id, err := parseYoutubeURL(link)
+	require.NoError(t, err)
+	require.Equal(t, model.TypeHandle, kind)
+	require.Equal(t, "username", id)
+
+	// Test handle URL with /videos
+	link, _ = url.ParseRequestURI("https://youtube.com/@testchannel/videos")
+	kind, id, err = parseYoutubeURL(link)
+	require.NoError(t, err)
+	require.Equal(t, model.TypeHandle, kind)
+	require.Equal(t, "testchannel", id)
+
+	// Test handle URL without www
+	link, _ = url.ParseRequestURI("https://youtube.com/@myhandle")
+	kind, id, err = parseYoutubeURL(link)
+	require.NoError(t, err)
+	require.Equal(t, model.TypeHandle, kind)
+	require.Equal(t, "myhandle", id)
+}
+
 func TestParseYoutubeURL_InvalidLink(t *testing.T) {
 	link, _ := url.ParseRequestURI("https://www.youtube.com/user///")
 	_, _, err := parseYoutubeURL(link)
 	require.Error(t, err)
 
 	link, _ = url.ParseRequestURI("https://www.youtube.com/channel//videos")
+	_, _, err = parseYoutubeURL(link)
+	require.Error(t, err)
+
+	// Test invalid handle URLs
+	link, _ = url.ParseRequestURI("https://www.youtube.com/@")
+	_, _, err = parseYoutubeURL(link)
+	require.Error(t, err)
+
+	link, _ = url.ParseRequestURI("https://www.youtube.com/")
+	_, _, err = parseYoutubeURL(link)
+	require.Error(t, err)
+
+	// Test handle without @ symbol
+	link, _ = url.ParseRequestURI("https://www.youtube.com/username")
 	_, _, err = parseYoutubeURL(link)
 	require.Error(t, err)
 }

--- a/pkg/model/link.go
+++ b/pkg/model/link.go
@@ -7,6 +7,7 @@ const (
 	TypePlaylist = Type("playlist")
 	TypeUser     = Type("user")
 	TypeGroup    = Type("group")
+	TypeHandle   = Type("handle")
 )
 
 type Provider string


### PR DESCRIPTION
Implements support for YouTube's new @handle URL format. Uses the Search API to resolve handles to channel IDs while maintaining full backward compatibility with existing channel and user URLs.

Users can now use handle URLs in their configurations:
```toml
[feeds.example]
url = "https://www.youtube.com/@mkbhd"
```

Reimplements https://github.com/mxpv/podsync/pull/717
Closes https://github.com/mxpv/podsync/issues/469
Ref https://github.com/mxpv/podsync/pull/475