### PR TITLE
Prevent initial update when cron_schedule is explicitly configured

### DIFF
--- a/cmd/podsync/main.go
+++ b/cmd/podsync/main.go
@@ -199,6 +199,9 @@ func main() {
 		var cronID cron.EntryID
 
 		for _, _feed := range cfg.Feeds {
+			// Track if this feed has an explicit cron schedule
+			hasExplicitCronSchedule := _feed.CronSchedule != ""
+			
 			if _feed.CronSchedule == "" {
 				_feed.CronSchedule = fmt.Sprintf("@every %s", _feed.UpdatePeriod.String())
 			}
@@ -212,8 +215,12 @@ func main() {
 
 			m[cronFeed.ID] = cronID
 			log.Debugf("-> %s (update '%s')", cronFeed.ID, cronFeed.CronSchedule)
-			// Perform initial update after CLI restart
-			updates <- cronFeed
+			
+			// Only perform initial update if no explicit cron schedule is configured
+			// This prevents unwanted updates when using fixed schedules in Docker deployments
+			if !hasExplicitCronSchedule {
+				updates <- cronFeed
+			}
 		}
 
 		c.Start()


### PR DESCRIPTION
Fixes #138

Skip initial feed update for feeds with explicit cron_schedule to prevent unwanted API calls and dependency issues in Docker deployments.

Generated with [Claude Code](https://claude.ai/code)