### PR TITLE
Replace realistic API key examples with generic placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ Podsync supports the following environment variables for configuration and API k
 | Variable Name                | Description                                                                               | Example Value(s)                              |
 |------------------------------|-------------------------------------------------------------------------------------------|-----------------------------------------------|
 | `PODSYNC_CONFIG_PATH`        | Path to the configuration file (overrides `--config` CLI flag)                            | `/app/config.toml`                            |
-| `PODSYNC_YOUTUBE_API_KEY`    | YouTube API key(s), space-separated for rotation                                          | `AIzaSyD4w2s-k79YNR98ABC` or `key1 key2 key3` |
-| `PODSYNC_VIMEO_API_KEY`      | Vimeo API key(s), space-separated for rotation                                            | `ecd4d34b07bcb9509ABCD` or `key1 key2`        |
+| `PODSYNC_YOUTUBE_API_KEY`    | YouTube API key(s), space-separated for rotation                                          | `key1` or `key1 key2 key3` |
+| `PODSYNC_VIMEO_API_KEY`      | Vimeo API key(s), space-separated for rotation                                            | `key1` or `key1 key2`        |
 | `PODSYNC_SOUNDCLOUD_API_KEY` | SoundCloud API key(s), space-separated for rotation                                       | `soundcloud_key1 soundcloud_key2`             |
 | `PODSYNC_TWITCH_API_KEY`     | Twitch API credentials in the format `CLIENT_ID:CLIENT_SECRET`, space-separated for multi | `id1:secret1 id2:secret2`                     |
 

--- a/docs/how_to_get_vimeo_token.md
+++ b/docs/how_to_get_vimeo_token.md
@@ -12,14 +12,14 @@
 7. Copy a token to your CLI's configuration file or set it as an environment variable.
 ```toml
 [tokens]
-vimeo = "ecd4d34b07bcb9509ABCD"
+vimeo = "key1"
 ```
 Or set the environment variable:
 ```sh
-export PODSYNC_VIMEO_API_KEY="ecd4d34b07bcb9509ABCD"
+export PODSYNC_VIMEO_API_KEY="key1"
 ```
 
 For API key rotation, you can specify multiple keys separated by spaces:
 ```sh
-export PODSYNC_VIMEO_API_KEY="ecd4d34b07bcb9509ABCD fdc5e45c18cda0610EFGH"
+export PODSYNC_VIMEO_API_KEY="key1 key2"
 ```

--- a/docs/how_to_get_youtube_api_key.md
+++ b/docs/how_to_get_youtube_api_key.md
@@ -19,14 +19,14 @@
 ![Copy token](img/youtube_copy_token.png)
 ```toml
 [tokens]
-youtube = "AIzaSyD4w2s-k79YNR98ABC"
+youtube = "key1"
 ```
 Or set the environment variable:
 ```sh
-export PODSYNC_YOUTUBE_API_KEY="AIzaSyD4w2s-k79YNR98ABC"
+export PODSYNC_YOUTUBE_API_KEY="key1"
 ```
 
 For API key rotation, you can specify multiple keys separated by spaces:
 ```sh
-export PODSYNC_YOUTUBE_API_KEY="AIzaSyD4w2s-k79YNR98ABC AIzaSyD4w2s-k79YNR98DEF"
+export PODSYNC_YOUTUBE_API_KEY="key1 key2"
 ```


### PR DESCRIPTION
Replace realistic-looking API key examples with generic placeholders to avoid confusion about whether these are real credentials. Addresses feedback from PR #747 comment.