### PR TITLE
Add build optimizations, use netgo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,7 @@ FROM alpine:3.21
 
 WORKDIR /app
 
-RUN apk --no-cache add ca-certificates python3 py3-pip ffmpeg tzdata \
-    # https://github.com/golang/go/issues/59305
-    libc6-compat && ln -s /lib/libc.so.6 /usr/lib/libresolv.so.2
+RUN apk --no-cache add ca-certificates python3 py3-pip ffmpeg tzdata libc6-compat
 
 COPY --from=builder /usr/bin/yt-dlp /usr/local/bin/youtube-dl
 COPY --from=builder /build/bin/podsync /app/podsync

--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,18 @@ TAG ?= $(shell git tag --points-at HEAD)
 COMMIT ?= $(shell git rev-parse --short HEAD)
 DATE := $(shell date)
 
-LDFLAGS := "-X 'main.version=${TAG}' -X 'main.commit=${COMMIT}' -X 'main.date=${DATE}' -X 'main.arch=${GOARCH}'"
+#
+# Go optimizations
+# -ldflags -s Remove symbol table
+# -ldflags -w Remove debug information
+# -trimpath Remove all file system paths from the compiled binary
+# -tags netgo Use the netgo network stack (Go DNS resolver)
+#
+LDFLAGS := "-s -w -X 'main.version=${TAG}' -X 'main.commit=${COMMIT}' -X 'main.date=${DATE}' -X 'main.arch=${GOARCH}'"
 
 .PHONY: build
 build:
-	go build -ldflags ${LDFLAGS} -o bin/podsync ./cmd/podsync
+	go build -trimpath -tags netgo -ldflags ${LDFLAGS} -o bin/podsync ./cmd/podsync
 
 #
 # Build a local Docker image


### PR DESCRIPTION
Hi @mxpv ,

This PR sets go build to use netgo for DNS resolution and a few bin size optimizations (it went from 33MB -> 23MB). Also dropped the link to /usr/lib/libresolv.so.2, which is no longer needed.