### PR TITLE
Improve episode cleanup routine

### DIFF
--- a/pkg/fs/local.go
+++ b/pkg/fs/local.go
@@ -2,6 +2,7 @@ package fs
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -37,7 +38,7 @@ func (l *Local) Open(name string) (http.File, error) {
 func (l *Local) Delete(_ctx context.Context, name string) error {
 	path := filepath.Join(l.rootDir, name)
 	if err := os.Remove(path); err != nil {
-		return err
+		return fmt.Errorf("failed to delete file %s: %w", path, err)
 	}
 	return nil
 }

--- a/pkg/fs/local.go
+++ b/pkg/fs/local.go
@@ -36,7 +36,10 @@ func (l *Local) Open(name string) (http.File, error) {
 
 func (l *Local) Delete(_ctx context.Context, name string) error {
 	path := filepath.Join(l.rootDir, name)
-	return os.Remove(path)
+	if err := os.Remove(path); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (l *Local) Create(_ctx context.Context, name string, reader io.Reader) (int64, error) {

--- a/pkg/fs/local_test.go
+++ b/pkg/fs/local_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -79,6 +80,9 @@ func TestLocal_Delete(t *testing.T) {
 
 	_, err = os.Stat(filepath.Join(tmpDir, "1", "test"))
 	assert.True(t, os.IsNotExist(err))
+
+	err = stor.Delete(testCtx, "1/test")
+	assert.True(t, errors.Is(err, os.ErrNotExist))
 }
 
 func TestLocal_copyFile(t *testing.T) {

--- a/pkg/fs/s3.go
+++ b/pkg/fs/s3.go
@@ -65,6 +65,13 @@ func (s *S3) Delete(ctx context.Context, name string) error {
 		Bucket: &s.bucket,
 		Key:    &key,
 	})
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok {
+			if awsErr.Code() == "NotFound" {
+				return os.ErrNotExist
+			}
+		}
+	}
 	return err
 }
 

--- a/pkg/fs/s3_test.go
+++ b/pkg/fs/s3_test.go
@@ -72,7 +72,6 @@ func TestS3_Delete(t *testing.T) {
 
 	err = stor.Delete(testCtx, "1/test")
 	assert.True(t, errors.Is(err, os.ErrNotExist))
-
 }
 
 func TestS3_BuildKey(t *testing.T) {

--- a/pkg/fs/s3_test.go
+++ b/pkg/fs/s3_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -64,10 +65,14 @@ func TestS3_Delete(t *testing.T) {
 	assert.NoError(t, err)
 
 	_, err = stor.Size(testCtx, "1/test")
-	assert.True(t, os.IsNotExist(err))
+	assert.True(t, errors.Is(err, os.ErrNotExist))
 
 	_, ok := files["1/test"]
 	assert.False(t, ok)
+
+	err = stor.Delete(testCtx, "1/test")
+	assert.True(t, errors.Is(err, os.ErrNotExist))
+
 }
 
 func TestS3_BuildKey(t *testing.T) {


### PR DESCRIPTION

Hi @mxpv ,

I did some manual cleanup of downloaded episodes and that broke the consistency between the DB and reality. 

So I updated the cleanup logic to be more tolerant to these situations - and remove file references from the DB if the file is no longer present.

Example of how it worked in my setup:
```
time="2025-08-20T15:44:44Z" level=info msg="running cleaner" count=20 feed_id=world_sci_festival
time="2025-08-20T15:44:44Z" level=info msg="deleting \"Infinite Beginnings? Time in Cutting Edge Cosmology\"" episode_id=_DMbOtpRSk0 feed_id=world_sci_festival
time="2025-08-20T15:44:44Z" level=info msg="episode was not found - file does not exist" episode_id=_DMbOtpRSk0 feed_id=world_sci_festival
time="2025-08-20T15:44:44Z" level=info msg="deleting \"Consciousness, Free Will, and Psychedelics: Exploring Mysteries of the Mind\"" episode_id=C9bqa8hRonE feed_id=world_sci_festival
time="2025-08-20T15:44:44Z" level=info msg="episode was not found - file does not exist" episode_id=C9bqa8hRonE feed_id=world_sci_festival
time="2025-08-20T15:44:44Z" level=info msg="deleting \"Straight Talk on Quantum Computing\"" episode_id=AVYRW9Qdp7Q feed_id=world_sci_festival
time="2025-08-20T15:44:44Z" level=info msg="episode was not found - file does not exist" episode_id=AVYRW9Qdp7Q feed_id=world_sci_festival
...
```

(Consequent runs were _clean_)