### PR TITLE
Update Go version from 1.24 to 1.25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.24
+          go-version: 1.25
       - uses: actions/checkout@v5
       - run: make build
       - uses: actions/upload-artifact@v4
@@ -42,7 +42,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.24
+          go-version: 1.25
       - uses: actions/checkout@v5
       - env:
           VIMEO_TEST_API_KEY: ${{ secrets.VIMEO_ACCESS_TOKEN }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mxpv/podsync
 
-go 1.24
+go 1.25
 
 require (
 	github.com/BrianHicks/finch v0.0.0-20140409222414-419bd73c29ec


### PR DESCRIPTION
- Update go.mod to use Go 1.25
- Update CI workflow to use Go 1.25 for build and test jobs
- Aligns with Dockerfile which already uses Go 1.25