### PR TITLE
feat: add error webhook

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -128,6 +128,15 @@ vimeo = [ # Multiple keys will be rotated.
   command = ["/path/to/your/process-episode.sh"]
   timeout = 120
 
+  # Optional episode download error hooks
+  # Execute commands when an episode download fails (e.g. to notify on cookie expiry)
+  # Available environment variables: FEED_NAME, EPISODE_TITLE, ERROR_MESSAGE
+
+  # Webhook notification example
+  [[feeds.ID1.on_episode_download_error]]
+  command = ["curl", "-X", "POST", "-d", "Download failed for $FEED_NAME: $ERROR_MESSAGE", "https://webhook.example.com/notify"]
+  timeout = 30
+
   # Optional feed customizations
   [feeds.ID1.custom]
   title = "Level1News"

--- a/pkg/feed/config.go
+++ b/pkg/feed/config.go
@@ -45,6 +45,14 @@ type Config struct {
 	//   command = ["echo", "Downloaded: $EPISODE_TITLE"]
 	//   timeout = 10
 	PostEpisodeDownload []*ExecHook `toml:"post_episode_download"`
+	// Episode download error hooks - executed when an episode download fails
+	// Available environment variables: FEED_NAME, EPISODE_TITLE, ERROR_MESSAGE
+	// Multiple hooks can be configured and will execute in sequence
+	// Example:
+	//   [[feeds.ID1.on_episode_download_error]]
+	//   command = ["curl", "-X", "POST", "-d", "Download failed: $ERROR_MESSAGE", "https://webhook.example.com/notify"]
+	//   timeout = 30
+	OnEpisodeDownloadError []*ExecHook `toml:"on_episode_download_error"`
 	// Included in OPML file
 	OPML bool `toml:"opml"`
 	// Private feed (not indexed by podcast aggregators)


### PR DESCRIPTION
This PR adds a new webhook that is fired when the download of an episode fails. This would be useful for me to be notified when my youtube cookies aren't working anymore and need to be rotated.

I've taken a lot of inspiration on the existing success webhook - it's basically the same deal. 