### PR TITLE
Bump Alpine to 1.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ RUN make build
 RUN wget -O /usr/bin/yt-dlp https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp && \
     chmod a+rwx /usr/bin/yt-dlp
 
-# Alpine 3.22 will go EOL on 2027-05-01
-FROM alpine:3.22
+# Alpine 3.24 will go EOL on 2028-05-01
+FROM alpine:3.24
 
 WORKDIR /app
 


### PR DESCRIPTION
yt-dlp started requiring deno 2.3.0 at a minimum.
Ref: https://github.com/yt-dlp/yt-dlp/releases/tag/2026.06.09

Alpine 1.22 provides 2.3.1-r2
Alpine 1.23 provides 2.3.1-r5
Alpine 1.24 provides 2.7.4-r2

I bumped Alpine to 1.24 to ensure continuous support. This change also updates ffmpeg from 6.1.2 to 8.1.1