### PR TITLE
feat: Ability to re-include older episodes when max_age is increased

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,9 +38,12 @@ Understanding how episodes flow through the system:
 
 ### Discovery Phase
 - Episodes are discovered during feed updates via platform APIs (YouTube Data API v3, Vimeo API, SoundCloud, Twitch)
-- `updateFeed()` in `services/update/updater.go:99-154` queries the platform API
+- `updateFeed()` in `services/update/updater.go:99-169` queries the platform API
 - New episodes are stored in BadgerDB with status `EpisodeNew`
 - Episodes matching feed URL are identified by provider-specific parsing in `pkg/builder/`
+- **Discovery depth (`max_age`-driven deep scan)**: normal updates do a shallow scan (the `page_size` most-recent episodes). To discover **never-before-seen** older episodes after `max_age` is increased, the updater triggers a one-time deep scan that pages the channel back to the `max_age` cutoff instead of stopping at `page_size`. The decision lives in `discoveryWindow()` (`services/update/updater.go`): each feed record stores `ScannedThrough`, a high-water mark of the oldest publish date discovery has paged to; a deep scan runs only when the `max_age` cutoff is older than `ScannedThrough` (i.e. `max_age` was actually expanded), so it costs nothing in steady state. The cutoff is passed to the builder via `feed.Config.DiscoverSince` (runtime-only field); the YouTube builder honors it in `queryItemsSince()`, bounded by `maxDeepScanPages` (20) as a quota backstop. `nextScannedThrough()` advances the mark to the cutoff only once every matching in-range episode is downloaded/cleaned/errored, so multi-cycle catch-up (bounded by `page_size` downloads per cycle) isn't truncated by episode pruning. Brand-new feeds stay shallow (no surprise back-catalog download). Currently implemented for YouTube only.
+- Previously cleaned episodes (`EpisodeCleaned`) that match the current filters again (e.g. after `max_age` is increased) are re-queued: status is reset to `EpisodeNew` (`resurrectEpisodes()` in `services/update/updater.go`). This works **off the database records directly, so it is independent of the `page_size` API window** — a cleaned episode no longer needs to be returned by the current feed query to be re-included. Cleaned records retain their metadata (see cleanup phase), so filters are evaluated against the stored title/description. Episodes cleaned by older podsync versions had their title/description wiped; for those the metadata is recovered from the current feed query (the deep-discovery scan brings in-range episodes back into the result with fresh metadata). An episode that still has no title — not in the DB and not in the feed query — is left cleaned until a later cycle surfaces it. When `keep_last` is configured, only episodes that would survive the next cleanup are re-queued (ranked by `PubDate` via `keepLastSurvivors()`), to avoid a re-download/re-clean loop.
+- Feed XML build (`feed.Build()` in `pkg/feed/xml.go`) skips any downloaded episode with an empty title (logging a warning) instead of aborting the entire feed build for one malformed item. (Original podsync aborted the whole feed on any empty title/description.)
 
 ### Download Phase
 - `fetchEpisodes()` iterates episodes with status `EpisodeNew` or `EpisodeError`
@@ -51,12 +54,13 @@ Understanding how episodes flow through the system:
 - On failure: status set to `EpisodeError`, retry attempted next cycle
 
 ### Cleanup Phase (Important!)
-- `cleanup()` in `updater.go:373-441` runs AFTER each successful update cycle
+- `cleanup()` in `updater.go:456-524` runs AFTER each successful update cycle
 - **Only triggered if `clean.keep_last` is configured** (global or per-feed)
 - Keeps most recent N episodes by PubDate (descending order)
-- Deleted episodes have status changed to `EpisodeCleaned` and title/description cleared
+- Deleted episodes have status changed to `EpisodeCleaned`; their title/description are **retained** so the record can be resurrected later (e.g. after `max_age` is increased) without losing metadata. Cleaned episodes are excluded from the feed by status, so keeping metadata has no effect on output.
 - **Files are deleted from storage but database records are retained**
 - This is a soft-delete: episodes remain in the database forever
+- **`keep_last` vs `page_size`**: a shallow update only sees `page_size` episodes, so on its own it can't fill a larger retention window. This is fine when `max_age` is set (the deep-discovery scan covers the look-back — see Discovery Phase) or when episodes were already discovered earlier. A startup warning is logged only when `clean.keep_last > page_size` **and** no `max_age` is configured (`applyDefaults()` in `cmd/podsync/config.go`).
 
 ### Episode Removal from Database
 - Episodes are removed from the database only if they:

--- a/cmd/podsync/config.go
+++ b/cmd/podsync/config.go
@@ -167,7 +167,7 @@ func (c *Config) applyDefaults(configPath string) {
 		c.Database.Dir = filepath.Join(filepath.Dir(configPath), "db")
 	}
 
-	for _, _feed := range c.Feeds {
+	for id, _feed := range c.Feeds {
 		if _feed.UpdatePeriod == 0 {
 			_feed.UpdatePeriod = model.DefaultUpdatePeriod
 		}
@@ -195,6 +195,18 @@ func (c *Config) applyDefaults(configPath string) {
 		// Apply global cleanup policy if feed doesn't have its own
 		if _feed.Clean == nil && c.Cleanup != nil {
 			_feed.Clean = c.Cleanup
+		}
+
+		// keep_last greater than page_size means a normal (shallow) update only ever sees
+		// page_size episodes, so the retention window can never be filled. When max_age is set
+		// the updater performs a one-time deep discovery to cover it, so the mismatch is fine;
+		// only warn when there is no max_age to drive that deeper look-back.
+		if _feed.Clean != nil && _feed.Clean.KeepLast > _feed.PageSize && _feed.Filters.MaxAge <= 0 {
+			log.Warnf(
+				"feed %q: clean.keep_last (%d) is greater than page_size (%d) and no max_age is set; "+
+					"set page_size >= keep_last (or configure max_age) so the retention window can be filled",
+				id, _feed.Clean.KeepLast, _feed.PageSize,
+			)
 		}
 	}
 }

--- a/cmd/podsync/config_test.go
+++ b/cmd/podsync/config_test.go
@@ -1,15 +1,17 @@
 package main
 
 import (
+	"bytes"
 	"os"
 	"testing"
 	"time"
 
-	"github.com/mxpv/podsync/services/web"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/mxpv/podsync/pkg/model"
+	"github.com/mxpv/podsync/services/web"
 )
 
 func TestLoadConfig(t *testing.T) {
@@ -213,6 +215,81 @@ data_dir = "/data"
 	assert.EqualValues(t, feed.Quality, "high")
 	assert.EqualValues(t, feed.Custom.CoverArtQuality, "high")
 	assert.EqualValues(t, feed.Format, "video")
+}
+
+func TestKeepLastPageSizeWarning(t *testing.T) {
+	t.Run("warns when keep_last exceeds page_size and no max_age", func(t *testing.T) {
+		var buf bytes.Buffer
+		log.SetOutput(&buf)
+		t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+		const file = `
+[server]
+data_dir = "/data"
+
+[feeds]
+  [feeds.A]
+  url = "https://youtube.com/watch?v=ygIUF678y40"
+  page_size = 5
+  clean = { keep_last = 20 }
+`
+		path := setup(t, file)
+		defer os.Remove(path)
+
+		config, err := LoadConfig(path)
+		require.NoError(t, err)
+		require.NotNil(t, config)
+		assert.Contains(t, buf.String(), "clean.keep_last")
+	})
+
+	t.Run("does not warn when max_age is configured", func(t *testing.T) {
+		var buf bytes.Buffer
+		log.SetOutput(&buf)
+		t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+		const file = `
+[server]
+data_dir = "/data"
+
+[feeds]
+  [feeds.A]
+  url = "https://youtube.com/watch?v=ygIUF678y40"
+  page_size = 5
+  clean = { keep_last = 20 }
+  filters = { max_age = 30 }
+`
+		path := setup(t, file)
+		defer os.Remove(path)
+
+		config, err := LoadConfig(path)
+		require.NoError(t, err)
+		require.NotNil(t, config)
+		assert.NotContains(t, buf.String(), "clean.keep_last")
+	})
+
+	t.Run("does not warn when keep_last is within page_size", func(t *testing.T) {
+		var buf bytes.Buffer
+		log.SetOutput(&buf)
+		t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+		const file = `
+[server]
+data_dir = "/data"
+
+[feeds]
+  [feeds.A]
+  url = "https://youtube.com/watch?v=ygIUF678y40"
+  page_size = 50
+  clean = { keep_last = 20 }
+`
+		path := setup(t, file)
+		defer os.Remove(path)
+
+		config, err := LoadConfig(path)
+		require.NoError(t, err)
+		require.NotNil(t, config)
+		assert.NotContains(t, buf.String(), "clean.keep_last")
+	})
 }
 
 func TestHttpServerListenAddress(t *testing.T) {

--- a/pkg/builder/youtube.go
+++ b/pkg/builder/youtube.go
@@ -130,9 +130,10 @@ func (yt *YouTubeBuilder) listPlaylists(ctx context.Context, id, channelID strin
 
 // Cost: 3 units (call: 1, snippet: 2)
 // See https://developers.google.com/youtube/v3/docs/playlistItems/list#part
-func (yt *YouTubeBuilder) listPlaylistItems(ctx context.Context, feed *model.Feed, pageToken string) ([]*youtube.PlaylistItem, string, error) {
+func (yt *YouTubeBuilder) listPlaylistItems(ctx context.Context, feed *model.Feed, pageToken string, fullPage bool) ([]*youtube.PlaylistItem, string, error) {
 	count := maxYoutubeResults
-	if count > feed.PageSize {
+	// During a deep (max_age-driven) scan we page through full result sets regardless of PageSize.
+	if !fullPage && count > feed.PageSize {
 		// If we need less than 50
 		count = feed.PageSize
 	}
@@ -412,7 +413,11 @@ func (yt *YouTubeBuilder) queryVideoDescriptions(ctx context.Context, playlist m
 // Cost:
 // ASC mode = (3 units + 5 units) * X pages = 8 units per page
 // DESC mode = 3 units * (number of pages in the entire playlist) + 5 units
-func (yt *YouTubeBuilder) queryItems(ctx context.Context, feed *model.Feed) error {
+func (yt *YouTubeBuilder) queryItems(ctx context.Context, feed *model.Feed, since time.Time) error {
+	if !since.IsZero() {
+		return yt.queryItemsSince(ctx, feed, since)
+	}
+
 	var (
 		token       string
 		count       int
@@ -420,7 +425,7 @@ func (yt *YouTubeBuilder) queryItems(ctx context.Context, feed *model.Feed) erro
 	)
 
 	for {
-		items, pageToken, err := yt.listPlaylistItems(ctx, feed, token)
+		items, pageToken, err := yt.listPlaylistItems(ctx, feed, token, false)
 		if err != nil {
 			return err
 		}
@@ -450,17 +455,69 @@ func (yt *YouTubeBuilder) queryItems(ctx context.Context, feed *model.Feed) erro
 		}
 	}
 
+	return yt.queryDescriptionsForSnippets(ctx, allSnippets, feed)
+}
+
+// maxDeepScanPages bounds a max_age-driven discovery pass as a quota backstop.
+const maxDeepScanPages = 20
+
+// queryItemsSince pages back through the channel until episodes are older than the cutoff
+// (a max_age-driven deep scan), instead of stopping at PageSize. It is bounded by
+// maxDeepScanPages to guard against a misconfigured max_age draining API quota.
+func (yt *YouTubeBuilder) queryItemsSince(ctx context.Context, feed *model.Feed, since time.Time) error {
+	var (
+		token       string
+		pages       int
+		allSnippets []*youtube.PlaylistItemSnippet
+	)
+
+	for {
+		items, pageToken, err := yt.listPlaylistItems(ctx, feed, token, true)
+		if err != nil {
+			return err
+		}
+
+		token = pageToken
+		pages++
+
+		if len(items) == 0 {
+			break
+		}
+
+		reachedCutoff := false
+		for _, item := range items {
+			// Keep only episodes within the requested window; the page that crosses the
+			// cutoff is where we stop.
+			if date, err := yt.parseDate(item.Snippet.PublishedAt); err == nil {
+				if date.Before(since) {
+					reachedCutoff = true
+					continue
+				}
+			}
+			allSnippets = append(allSnippets, item.Snippet)
+		}
+
+		if reachedCutoff || token == "" {
+			break
+		}
+
+		if pages >= maxDeepScanPages {
+			log.Warnf("deep scan for feed %q reached the %d-page cap before covering max_age; older episodes were not discovered (consider lowering max_age)", feed.ItemID, maxDeepScanPages)
+			break
+		}
+	}
+
+	return yt.queryDescriptionsForSnippets(ctx, allSnippets, feed)
+}
+
+func (yt *YouTubeBuilder) queryDescriptionsForSnippets(ctx context.Context, allSnippets []*youtube.PlaylistItemSnippet, feed *model.Feed) error {
 	snippets := map[string]*youtube.PlaylistItemSnippet{}
 	for _, snippet := range allSnippets {
 		snippets[snippet.ResourceId.VideoId] = snippet
 	}
 
 	// Query video descriptions from the list of ids
-	if err := yt.queryVideoDescriptions(ctx, snippets, feed); err != nil {
-		return err
-	}
-
-	return nil
+	return yt.queryVideoDescriptions(ctx, snippets, feed)
 }
 
 func (yt *YouTubeBuilder) Build(ctx context.Context, cfg *feed.Config) (*model.Feed, error) {
@@ -491,13 +548,14 @@ func (yt *YouTubeBuilder) Build(ctx context.Context, cfg *feed.Config) (*model.F
 		return nil, err
 	}
 
-	if err := yt.queryItems(ctx, _feed); err != nil {
+	if err := yt.queryItems(ctx, _feed, cfg.DiscoverSince); err != nil {
 		return nil, err
 	}
 
 	// YT API client gets 50 episodes per query.
-	// Round up to page size.
-	if len(_feed.Episodes) > _feed.PageSize {
+	// Round up to page size, unless a deep (max_age-driven) scan is requested, in which case
+	// we keep every episode within the window so the caller can catch up the back-catalog.
+	if cfg.DiscoverSince.IsZero() && len(_feed.Episodes) > _feed.PageSize {
 		_feed.Episodes = _feed.Episodes[:_feed.PageSize]
 	}
 

--- a/pkg/feed/config.go
+++ b/pkg/feed/config.go
@@ -62,6 +62,10 @@ type Config struct {
 	// FilenameTemplate controls output media filename (without extension)
 	// Supported tokens: {{id}}, {{title}}, {{pub_date}}, {{feed_id}}
 	FilenameTemplate string `toml:"filename_template"`
+	// DiscoverSince is a runtime-only hint (not configurable) set by the updater to request a
+	// deep discovery pass: the builder pages back through the channel until episodes are older
+	// than this date instead of stopping at PageSize. Zero means the default shallow discovery.
+	DiscoverSince time.Time `toml:"-"`
 }
 
 type CustomFormat struct {

--- a/pkg/feed/xml.go
+++ b/pkg/feed/xml.go
@@ -11,6 +11,7 @@ import (
 
 	itunes "github.com/eduncan911/podcast"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/mxpv/podsync/pkg/model"
 )
@@ -166,6 +167,14 @@ func Build(_ctx context.Context, feed *model.Feed, cfg *Config, hostname string)
 		)
 
 		item.AddEnclosure(downloadURL, enclosureType, episode.Size)
+
+		// p.AddItem requires a non-empty title. An episode without one cannot be
+		// represented in the feed (e.g. metadata was never populated), so skip it
+		// instead of failing the whole feed build for every other episode.
+		if item.Title == "" {
+			log.Warnf("skipping episode %q in feed %q: missing title", episode.ID, cfg.ID)
+			continue
+		}
 
 		// p.AddItem requires description to be not empty, use workaround
 		if item.Description == "" {

--- a/pkg/feed/xml_test.go
+++ b/pkg/feed/xml_test.go
@@ -48,6 +48,32 @@ func TestBuildXML(t *testing.T) {
 	assert.EqualValues(t, out.Items[0].Enclosure.Type, itunes.MP4)
 }
 
+func TestBuildXMLSkipsEpisodeWithoutTitle(t *testing.T) {
+	feed := model.Feed{
+		Episodes: []*model.Episode{
+			{
+				ID:          "no-title",
+				Status:      model.EpisodeDownloaded,
+				Description: "description",
+			},
+			{
+				ID:          "ok",
+				Status:      model.EpisodeDownloaded,
+				Title:       "title",
+				Description: "description",
+			},
+		},
+	}
+
+	cfg := Config{ID: "test"}
+
+	out, err := Build(context.Background(), &feed, &cfg, "http://localhost/")
+	// A single episode with a missing title must not fail the whole feed build
+	require.NoError(t, err)
+	require.Len(t, out.Items, 1)
+	assert.Equal(t, "ok", out.Items[0].GUID)
+}
+
 func TestBuildXMLWithFilenameTemplate(t *testing.T) {
 	feed := model.Feed{
 		Episodes: []*model.Episode{

--- a/pkg/model/feed.go
+++ b/pkg/model/feed.go
@@ -65,6 +65,10 @@ type Feed struct {
 	UpdatedAt       time.Time  `json:"updated_at"`
 	PlaylistSort    Sorting    `json:"playlist_sort"`
 	PrivateFeed     bool       `json:"private_feed"`
+	// ScannedThrough is the oldest publish date discovery has paged back to. It is a high-water
+	// mark used to decide when max_age has been expanded beyond what was ever scanned, so a deep
+	// (max_age-driven) discovery pass is only triggered once per expansion instead of every cycle.
+	ScannedThrough time.Time `json:"scanned_through"`
 }
 
 type EpisodeStatus string

--- a/services/update/matcher.go
+++ b/services/update/matcher.go
@@ -42,6 +42,13 @@ func matchFilters(episode *model.Episode, filters *feed.Filters) bool {
 		return false
 	}
 
+	return matchDurationAndAge(episode, filters, logger)
+}
+
+// matchDurationAndAge evaluates the filters that depend only on metadata that is always
+// present on an episode record (duration and publish date). It is used as a cheap pre-filter
+// for cleaned episodes, whose title/description may have to be fetched separately.
+func matchDurationAndAge(episode *model.Episode, filters *feed.Filters, logger log.FieldLogger) bool {
 	if filters.MaxDuration > 0 && episode.Duration > filters.MaxDuration {
 		logger.WithField("filter", "max_duration").Infof("skipping due to duration filter (%ds)", episode.Duration)
 		return false

--- a/services/update/updater.go
+++ b/services/update/updater.go
@@ -166,13 +166,6 @@ func (u *Manager) updateFeed(ctx context.Context, feedConfig *feed.Config) error
 		return err
 	}
 
-	// Carry forward the discovery high-water mark so the deep scan only repeats while catching up.
-	result.ScannedThrough = nextScannedThrough(since, watermark, result, processed, &feedConfig.Filters)
-
-	if err := u.db.AddFeed(ctx, feedConfig.ID, result); err != nil {
-		return err
-	}
-
 	for _, episode := range result.Episodes {
 		delete(episodeSet, episode.ID)
 	}
@@ -186,7 +179,23 @@ func (u *Manager) updateFeed(ctx context.Context, feedConfig *feed.Config) error
 		}
 	}
 
-	if err := u.resurrectEpisodes(feedConfig, cleaned, downloaded, apiEpisodes); err != nil {
+	resurrected, err := u.resurrectEpisodes(feedConfig, cleaned, downloaded, apiEpisodes)
+	if err != nil {
+		return err
+	}
+
+	// Resurrected episodes were just flipped from cleaned back to EpisodeNew, so they are pending
+	// download again, not "processed". Drop them so the deep-scan high-water mark does not advance
+	// past episodes that still need to download; otherwise the next shallow cycle would prune them
+	// before they finish.
+	for id := range resurrected {
+		delete(processed, id)
+	}
+
+	// Carry forward the discovery high-water mark so the deep scan only repeats while catching up.
+	result.ScannedThrough = nextScannedThrough(since, watermark, result, processed, &feedConfig.Filters)
+
+	if err := u.db.AddFeed(ctx, feedConfig.ID, result); err != nil {
 		return err
 	}
 
@@ -289,8 +298,9 @@ func oldestPubDate(episodes []*model.Episode) time.Time {
 // filters again, e.g. when max_age is increased to cover episodes that were already downloaded
 // and deleted. It works off the database records directly, so re-inclusion does not depend on the
 // episode still being within the page_size API window.
-func (u *Manager) resurrectEpisodes(feedConfig *feed.Config, cleaned, downloaded []*model.Episode, apiEpisodes map[string]*model.Episode) error {
+func (u *Manager) resurrectEpisodes(feedConfig *feed.Config, cleaned, downloaded []*model.Episode, apiEpisodes map[string]*model.Episode) (map[string]struct{}, error) {
 	filters := &feedConfig.Filters
+	resurrected := make(map[string]struct{})
 
 	// Cheap pre-filter on duration/age, which are always present on the record.
 	// Title/description filters are applied later, after any missing metadata is recovered.
@@ -302,7 +312,7 @@ func (u *Manager) resurrectEpisodes(feedConfig *feed.Config, cleaned, downloaded
 	}
 
 	if len(candidates) == 0 {
-		return nil
+		return resurrected, nil
 	}
 
 	// Resurrect only episodes that would survive the cleanup policy, otherwise
@@ -345,11 +355,12 @@ func (u *Manager) resurrectEpisodes(feedConfig *feed.Config, cleaned, downloaded
 			}
 			return nil
 		}); err != nil {
-			return errors.Wrapf(err, "failed to re-queue cleaned episode %s", episode.ID)
+			return nil, errors.Wrapf(err, "failed to re-queue cleaned episode %s", episode.ID)
 		}
+		resurrected[episode.ID] = struct{}{}
 	}
 
-	return nil
+	return resurrected, nil
 }
 
 // keepLastSurvivors returns the subset of candidates that would remain after applying the

--- a/services/update/updater.go
+++ b/services/update/updater.go
@@ -207,7 +207,11 @@ func (u *Manager) discoveryWindow(ctx context.Context, feedConfig *feed.Config) 
 
 	existing, err := u.db.GetFeed(ctx, feedConfig.ID)
 	if err != nil {
-		// Brand new feed: nothing scanned yet. Stay shallow to avoid a surprise back-catalog download.
+		if err == model.ErrNotFound {
+			// Brand new feed: nothing scanned yet. Stay shallow to avoid a surprise back-catalog download.
+			return time.Time{}, time.Time{}
+		}
+		log.WithError(err).WithField("feed_id", feedConfig.ID).Warn("failed to load existing feed for discovery-window calculation; staying shallow")
 		return time.Time{}, time.Time{}
 	}
 

--- a/services/update/updater.go
+++ b/services/update/updater.go
@@ -23,6 +23,7 @@ import (
 
 type Downloader interface {
 	Download(ctx context.Context, feedConfig *feed.Config, episode *model.Episode) (io.ReadCloser, error)
+	// PlaylistMetadata is required by the platform builders (passed through to builder.New).
 	PlaylistMetadata(ctx context.Context, url string) (metadata ytdl.PlaylistMetadata, err error)
 }
 
@@ -113,24 +114,60 @@ func (u *Manager) updateFeed(ctx context.Context, feedConfig *feed.Config) error
 		return err
 	}
 
+	// Decide how far back to discover. Normally this is a shallow scan (page_size); when max_age
+	// has been expanded beyond what was ever scanned, request a one-time deep scan to the cutoff.
+	since, watermark := u.discoveryWindow(ctx, feedConfig)
+	feedConfig.DiscoverSince = since
+	if !since.IsZero() {
+		log.WithField("feed_id", feedConfig.ID).Infof("max_age extended beyond scanned history, performing deep discovery back to %s", since.Format("2006-01-02"))
+	}
+
 	// Query API to get episodes
 	log.Debug("building feed")
 	result, err := provider.Build(ctx, feedConfig)
+	feedConfig.DiscoverSince = time.Time{} // consumed by the builder; don't leak into the next cycle
 	if err != nil {
 		return err
 	}
 
 	log.Debugf("received %d episode(s) for %q", len(result.Episodes), result.Title)
 
-	episodeSet := make(map[string]struct{})
+	// Index the fresh API metadata. Used to restore metadata for cleaned episodes that older
+	// versions stored without a title/description when they are resurrected.
+	apiEpisodes := make(map[string]*model.Episode, len(result.Episodes))
+	for _, episode := range result.Episodes {
+		apiEpisodes[episode.ID] = episode
+	}
+
+	var (
+		episodeSet = make(map[string]struct{})
+		cleaned    []*model.Episode
+		downloaded []*model.Episode
+		// processed holds episodes that don't need a first download attempt (downloaded, cleaned,
+		// or errored). Used to decide when a deep-scan catch-up is complete.
+		processed = make(map[string]struct{})
+	)
 	if err := u.db.WalkEpisodes(ctx, feedConfig.ID, func(episode *model.Episode) error {
-		if episode.Status != model.EpisodeDownloaded && episode.Status != model.EpisodeCleaned {
+		switch episode.Status {
+		case model.EpisodeDownloaded:
+			downloaded = append(downloaded, episode)
+			processed[episode.ID] = struct{}{}
+		case model.EpisodeCleaned:
+			cleaned = append(cleaned, episode)
+			processed[episode.ID] = struct{}{}
+		default:
 			episodeSet[episode.ID] = struct{}{}
+			if episode.Status == model.EpisodeError {
+				processed[episode.ID] = struct{}{}
+			}
 		}
 		return nil
 	}); err != nil {
 		return err
 	}
+
+	// Carry forward the discovery high-water mark so the deep scan only repeats while catching up.
+	result.ScannedThrough = nextScannedThrough(since, watermark, result, processed, &feedConfig.Filters)
 
 	if err := u.db.AddFeed(ctx, feedConfig.ID, result); err != nil {
 		return err
@@ -149,8 +186,194 @@ func (u *Manager) updateFeed(ctx context.Context, feedConfig *feed.Config) error
 		}
 	}
 
+	if err := u.resurrectEpisodes(feedConfig, cleaned, downloaded, apiEpisodes); err != nil {
+		return err
+	}
+
 	log.Debug("successfully saved updates to storage")
 	return nil
+}
+
+// discoveryWindow decides whether the next build should perform a deep (max_age-driven) discovery
+// pass. It returns the cutoff date to page back to (zero means the normal shallow discovery) and
+// the current scan high-water mark to carry forward. A deep scan is requested only when max_age
+// now reaches further back than anything previously scanned, so it happens once per expansion
+// rather than every cycle.
+func (u *Manager) discoveryWindow(ctx context.Context, feedConfig *feed.Config) (since, watermark time.Time) {
+	maxAge := feedConfig.Filters.MaxAge
+	if maxAge <= 0 {
+		return time.Time{}, time.Time{}
+	}
+
+	existing, err := u.db.GetFeed(ctx, feedConfig.ID)
+	if err != nil {
+		// Brand new feed: nothing scanned yet. Stay shallow to avoid a surprise back-catalog download.
+		return time.Time{}, time.Time{}
+	}
+
+	watermark = existing.ScannedThrough
+	if watermark.IsZero() {
+		// Upgrade path (feed predates this field): derive the mark from the oldest episode we have
+		// already processed, so an expansion past it still triggers a one-time catch-up.
+		watermark = oldestProcessedPubDate(existing.Episodes)
+	}
+	if watermark.IsZero() {
+		return time.Time{}, watermark
+	}
+
+	cutoff := time.Now().AddDate(0, 0, -maxAge)
+	if cutoff.Before(watermark) {
+		return cutoff, watermark
+	}
+	return time.Time{}, watermark
+}
+
+// nextScannedThrough computes the discovery high-water mark to persist after a build. On a shallow
+// scan it preserves the existing mark (or establishes a baseline for a new feed). On a deep scan it
+// advances the mark to the cutoff only once every matching in-range episode is accounted for
+// (downloaded, cleaned, or errored); until then it keeps the old mark so the next cycle scans deep
+// again and the freshly discovered episodes are not pruned before they finish downloading.
+func nextScannedThrough(since, watermark time.Time, result *model.Feed, processed map[string]struct{}, filters *feed.Filters) time.Time {
+	if since.IsZero() {
+		if !watermark.IsZero() {
+			return watermark
+		}
+		return oldestPubDate(result.Episodes)
+	}
+
+	for _, episode := range result.Episodes {
+		if !matchFilters(episode, filters) {
+			continue
+		}
+		if _, ok := processed[episode.ID]; !ok {
+			return watermark
+		}
+	}
+	return since
+}
+
+func oldestProcessedPubDate(episodes []*model.Episode) time.Time {
+	var oldest time.Time
+	for _, episode := range episodes {
+		if episode.Status != model.EpisodeDownloaded && episode.Status != model.EpisodeCleaned {
+			continue
+		}
+		if episode.PubDate.IsZero() {
+			continue
+		}
+		if oldest.IsZero() || episode.PubDate.Before(oldest) {
+			oldest = episode.PubDate
+		}
+	}
+	return oldest
+}
+
+func oldestPubDate(episodes []*model.Episode) time.Time {
+	var oldest time.Time
+	for _, episode := range episodes {
+		if episode.PubDate.IsZero() {
+			continue
+		}
+		if oldest.IsZero() || episode.PubDate.Before(oldest) {
+			oldest = episode.PubDate
+		}
+	}
+	return oldest
+}
+
+// resurrectEpisodes re-queues previously cleaned (soft-deleted) episodes that match the current
+// filters again, e.g. when max_age is increased to cover episodes that were already downloaded
+// and deleted. It works off the database records directly, so re-inclusion does not depend on the
+// episode still being within the page_size API window.
+func (u *Manager) resurrectEpisodes(feedConfig *feed.Config, cleaned, downloaded []*model.Episode, apiEpisodes map[string]*model.Episode) error {
+	filters := &feedConfig.Filters
+
+	// Cheap pre-filter on duration/age, which are always present on the record.
+	// Title/description filters are applied later, after any missing metadata is recovered.
+	var candidates []*model.Episode
+	for _, episode := range cleaned {
+		if matchDurationAndAge(episode, filters, log.WithField("episode_id", episode.ID)) {
+			candidates = append(candidates, episode)
+		}
+	}
+
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	// Resurrect only episodes that would survive the cleanup policy, otherwise
+	// every update cycle would re-download episodes just for cleanup to delete them again.
+	if feedConfig.Clean != nil && feedConfig.Clean.KeepLast > 0 {
+		candidates = keepLastSurvivors(candidates, downloaded, feedConfig.Clean.KeepLast)
+	}
+
+	for _, episode := range candidates {
+		// Episodes cleaned by older versions were stored without a title/description. Recover that
+		// metadata from the current feed query (the deep discovery scan brings in-range episodes
+		// back into the result), so title/description filters can be evaluated and the re-downloaded
+		// episode has metadata for the feed build.
+		if episode.Title == "" {
+			if api, ok := apiEpisodes[episode.ID]; ok {
+				episode.Title = api.Title
+				episode.Description = api.Description
+			}
+		}
+
+		// Without a title the episode cannot be published; leave it cleaned until it reappears in
+		// the feed query (e.g. once a deep scan covers it) and we can recover its metadata.
+		if episode.Title == "" {
+			continue
+		}
+
+		if !matchFilters(episode, filters) {
+			continue
+		}
+
+		log.WithField("episode_id", episode.ID).Info("re-queueing previously cleaned episode that matches filters again")
+		title, description := episode.Title, episode.Description
+		if err := u.db.UpdateEpisode(feedConfig.ID, episode.ID, func(saved *model.Episode) error {
+			saved.Status = model.EpisodeNew
+			if saved.Title == "" {
+				saved.Title = title
+			}
+			if saved.Description == "" {
+				saved.Description = description
+			}
+			return nil
+		}); err != nil {
+			return errors.Wrapf(err, "failed to re-queue cleaned episode %s", episode.ID)
+		}
+	}
+
+	return nil
+}
+
+// keepLastSurvivors returns the subset of candidates that would remain after applying the
+// keep_last cleanup policy, given the currently downloaded episodes. Ranking is by PubDate.
+func keepLastSurvivors(candidates, downloaded []*model.Episode, keepLast int) []*model.Episode {
+	all := make([]*model.Episode, 0, len(downloaded)+len(candidates))
+	all = append(all, downloaded...)
+	all = append(all, candidates...)
+	sort.Slice(all, func(i, j int) bool {
+		return all[i].PubDate.After(all[j].PubDate)
+	})
+
+	if len(all) > keepLast {
+		all = all[:keepLast]
+	}
+
+	surviving := make(map[string]struct{}, len(all))
+	for _, episode := range all {
+		surviving[episode.ID] = struct{}{}
+	}
+
+	kept := candidates[:0]
+	for _, episode := range candidates {
+		if _, ok := surviving[episode.ID]; ok {
+			kept = append(kept, episode)
+		}
+	}
+	return kept
 }
 
 func (u *Manager) fetchEpisodes(ctx context.Context, feedConfig *feed.Config) ([]*model.Episode, error) {
@@ -426,10 +649,12 @@ func (u *Manager) cleanup(ctx context.Context, feedConfig *feed.Config) error {
 			logger.WithField("episode_id", episode.ID).Info("episode was not found - file does not exist")
 		}
 
+		// Only the file is removed; the episode metadata is retained so the record
+		// can be resurrected later (e.g. when max_age is increased) without losing
+		// its title/description. Cleaned episodes are already excluded from the feed
+		// by their status, so keeping the metadata has no effect on the output.
 		if err := u.db.UpdateEpisode(feedID, episode.ID, func(episode *model.Episode) error {
 			episode.Status = model.EpisodeCleaned
-			episode.Title = ""
-			episode.Description = ""
 			return nil
 		}); err != nil {
 			result = multierror.Append(result, errors.Wrapf(err, "failed to set state for cleaned episode: %s", episode.ID))

--- a/services/update/updater_test.go
+++ b/services/update/updater_test.go
@@ -240,7 +240,8 @@ func TestResurrectCleanedEpisodeMatchingFiltersAgain(t *testing.T) {
 
 	cfg := &feed.Config{ID: "1", Filters: feed.Filters{MaxAge: 60}}
 
-	require.NoError(t, manager.resurrectEpisodes(cfg, cleaned, nil, nil))
+	_, err := manager.resurrectEpisodes(cfg, cleaned, nil, nil)
+	require.NoError(t, err)
 
 	episode, err := manager.db.GetEpisode(ctx, "1", "old")
 	require.NoError(t, err)
@@ -267,7 +268,8 @@ func TestResurrectRecoversWipedMetadataFromAPIResult(t *testing.T) {
 
 	cfg := &feed.Config{ID: "1", Filters: feed.Filters{MaxAge: 60, MinDuration: 120}}
 
-	require.NoError(t, manager.resurrectEpisodes(cfg, cleaned, nil, apiEpisodes))
+	_, err := manager.resurrectEpisodes(cfg, cleaned, nil, apiEpisodes)
+	require.NoError(t, err)
 
 	episode, err := manager.db.GetEpisode(ctx, "1", "old")
 	require.NoError(t, err)
@@ -290,7 +292,8 @@ func TestResurrectSkipsWipedEpisodeWithoutAPIMetadata(t *testing.T) {
 	cfg := &feed.Config{ID: "1", Filters: feed.Filters{MaxAge: 60, MinDuration: 120}}
 
 	// No apiEpisodes: nothing to title the episode with, so it stays cleaned for now
-	require.NoError(t, manager.resurrectEpisodes(cfg, cleaned, nil, map[string]*model.Episode{}))
+	_, err := manager.resurrectEpisodes(cfg, cleaned, nil, map[string]*model.Episode{})
+	require.NoError(t, err)
 
 	episode, err := manager.db.GetEpisode(ctx, "1", "old")
 	require.NoError(t, err)
@@ -310,7 +313,8 @@ func TestResurrectSkipsEpisodeFailingTextFilter(t *testing.T) {
 
 	cfg := &feed.Config{ID: "1", Filters: feed.Filters{MaxAge: 60, NotTitle: "(?i)live"}}
 
-	require.NoError(t, manager.resurrectEpisodes(cfg, cleaned, nil, nil))
+	_, err := manager.resurrectEpisodes(cfg, cleaned, nil, nil)
+	require.NoError(t, err)
 
 	episode, err := manager.db.GetEpisode(ctx, "1", "old")
 	require.NoError(t, err)
@@ -329,7 +333,8 @@ func TestResurrectSkipsEpisodeNotMatchingFilters(t *testing.T) {
 
 	cfg := &feed.Config{ID: "1", Filters: feed.Filters{MaxAge: 60}}
 
-	require.NoError(t, manager.resurrectEpisodes(cfg, cleaned, nil, nil))
+	_, err := manager.resurrectEpisodes(cfg, cleaned, nil, nil)
+	require.NoError(t, err)
 
 	episode, err := manager.db.GetEpisode(ctx, "1", "old")
 	require.NoError(t, err)
@@ -353,7 +358,8 @@ func TestResurrectSkipsEpisodeThatWouldBeCleanedAgain(t *testing.T) {
 	// the old one would result in cleanup deleting it again
 	cfg := &feed.Config{ID: "1", Clean: &feed.Cleanup{KeepLast: 1}}
 
-	require.NoError(t, manager.resurrectEpisodes(cfg, []*model.Episode{old}, []*model.Episode{downloaded}, nil))
+	_, err := manager.resurrectEpisodes(cfg, []*model.Episode{old}, []*model.Episode{downloaded}, nil)
+	require.NoError(t, err)
 
 	episode, err := manager.db.GetEpisode(ctx, "1", "old")
 	require.NoError(t, err)
@@ -375,12 +381,43 @@ func TestResurrectKeepsEpisodeWithinKeepLastWindow(t *testing.T) {
 
 	cfg := &feed.Config{ID: "1", Clean: &feed.Cleanup{KeepLast: 2}}
 
-	require.NoError(t, manager.resurrectEpisodes(cfg, []*model.Episode{old}, []*model.Episode{downloaded}, nil))
+	_, err := manager.resurrectEpisodes(cfg, []*model.Episode{old}, []*model.Episode{downloaded}, nil)
+	require.NoError(t, err)
 
 	episode, err := manager.db.GetEpisode(ctx, "1", "old")
 	require.NoError(t, err)
 	assert.Equal(t, model.EpisodeNew, episode.Status)
 	assert.Equal(t, "Old Episode", episode.Title)
+}
+
+func TestResurrectReportsResurrectedIDsHoldingWatermark(t *testing.T) {
+	manager := newTestManager(t)
+
+	pubDate := time.Now().AddDate(0, 0, -150)
+	old := &model.Episode{ID: "old", Title: "Old Episode", PubDate: pubDate, Status: model.EpisodeCleaned}
+	seedEpisodes(t, manager, "1", []*model.Episode{old})
+
+	cfg := &feed.Config{ID: "1", Filters: feed.Filters{MaxAge: 200}}
+
+	resurrected, err := manager.resurrectEpisodes(cfg, []*model.Episode{old}, nil, nil)
+	require.NoError(t, err)
+	require.Contains(t, resurrected, "old", "a re-queued episode must be reported so the watermark accounts for it")
+
+	// The episode is now pending download again. Removing it from the processed set must keep the
+	// deep-scan high-water mark from advancing past it, so the next cycle stays deep and the
+	// shallow removal loop cannot prune it before it downloads.
+	var (
+		watermark = time.Now().AddDate(0, 0, -100)
+		since     = time.Now().AddDate(0, 0, -200)
+		result    = &model.Feed{Episodes: []*model.Episode{old}}
+		processed = map[string]struct{}{"old": {}} // it was cleaned, so initially counted as done
+	)
+	for id := range resurrected {
+		delete(processed, id)
+	}
+
+	got := nextScannedThrough(since, watermark, result, processed, &cfg.Filters)
+	assert.Equal(t, watermark, got, "watermark must not advance while a resurrected episode is still pending")
 }
 
 func TestResurrectWithNoCleanedEpisodesDoesNothing(t *testing.T) {
@@ -394,7 +431,8 @@ func TestResurrectWithNoCleanedEpisodesDoesNothing(t *testing.T) {
 
 	cfg := &feed.Config{ID: "1"}
 
-	require.NoError(t, manager.resurrectEpisodes(cfg, nil, nil, nil))
+	_, err := manager.resurrectEpisodes(cfg, nil, nil, nil)
+	require.NoError(t, err)
 
 	episode, err := manager.db.GetEpisode(ctx, "1", "done")
 	require.NoError(t, err)

--- a/services/update/updater_test.go
+++ b/services/update/updater_test.go
@@ -1,0 +1,402 @@
+package update
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mxpv/podsync/pkg/db"
+	"github.com/mxpv/podsync/pkg/feed"
+	"github.com/mxpv/podsync/pkg/fs"
+	"github.com/mxpv/podsync/pkg/model"
+)
+
+func newTestManager(t *testing.T) *Manager {
+	t.Helper()
+
+	database, err := db.NewBadger(&db.Config{Dir: t.TempDir()})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = database.Close() })
+
+	return &Manager{db: database}
+}
+
+func seedEpisodes(t *testing.T, manager *Manager, feedID string, episodes []*model.Episode) {
+	t.Helper()
+
+	err := manager.db.AddFeed(context.Background(), feedID, &model.Feed{
+		ID:       feedID,
+		Episodes: episodes,
+	})
+	require.NoError(t, err)
+}
+
+func TestDiscoveryWindowNoMaxAgeStaysShallow(t *testing.T) {
+	manager := newTestManager(t)
+	ctx := context.Background()
+
+	require.NoError(t, manager.db.AddFeed(ctx, "1", &model.Feed{ID: "1", ScannedThrough: time.Now().AddDate(0, 0, -100)}))
+
+	since, _ := manager.discoveryWindow(ctx, &feed.Config{ID: "1"})
+	assert.True(t, since.IsZero(), "no max_age must never trigger a deep scan")
+}
+
+func TestDiscoveryWindowNewFeedStaysShallow(t *testing.T) {
+	manager := newTestManager(t)
+	ctx := context.Background()
+
+	// No feed record exists yet
+	since, _ := manager.discoveryWindow(ctx, &feed.Config{ID: "1", Filters: feed.Filters{MaxAge: 200}})
+	assert.True(t, since.IsZero(), "a brand new feed must not deep scan its back-catalog")
+}
+
+func TestDiscoveryWindowTriggersDeepScanWhenExpandedPastWatermark(t *testing.T) {
+	manager := newTestManager(t)
+	ctx := context.Background()
+
+	watermark := time.Now().AddDate(0, 0, -100)
+	require.NoError(t, manager.db.AddFeed(ctx, "1", &model.Feed{ID: "1", ScannedThrough: watermark}))
+
+	since, wm := manager.discoveryWindow(ctx, &feed.Config{ID: "1", Filters: feed.Filters{MaxAge: 200}})
+	require.False(t, since.IsZero(), "max_age reaching past the watermark must trigger a deep scan")
+	assert.WithinDuration(t, time.Now().AddDate(0, 0, -200), since, time.Hour)
+	assert.Equal(t, watermark.Unix(), wm.Unix())
+}
+
+func TestDiscoveryWindowStaysShallowWithinWatermark(t *testing.T) {
+	manager := newTestManager(t)
+	ctx := context.Background()
+
+	watermark := time.Now().AddDate(0, 0, -100)
+	require.NoError(t, manager.db.AddFeed(ctx, "1", &model.Feed{ID: "1", ScannedThrough: watermark}))
+
+	since, _ := manager.discoveryWindow(ctx, &feed.Config{ID: "1", Filters: feed.Filters{MaxAge: 50}})
+	assert.True(t, since.IsZero(), "max_age within the scanned window must not deep scan")
+}
+
+func TestDiscoveryWindowUpgradePathDerivesWatermarkFromEpisodes(t *testing.T) {
+	manager := newTestManager(t)
+	ctx := context.Background()
+
+	// Feed predating ScannedThrough: derive the mark from the oldest processed episode
+	require.NoError(t, manager.db.AddFeed(ctx, "1", &model.Feed{
+		ID: "1",
+		Episodes: []*model.Episode{
+			{ID: "old", PubDate: time.Now().AddDate(0, 0, -100), Status: model.EpisodeCleaned},
+			{ID: "recent", PubDate: time.Now().AddDate(0, 0, -2), Status: model.EpisodeDownloaded},
+		},
+	}))
+
+	since, _ := manager.discoveryWindow(ctx, &feed.Config{ID: "1", Filters: feed.Filters{MaxAge: 200}})
+	require.False(t, since.IsZero(), "expansion past the oldest processed episode must deep scan")
+	assert.WithinDuration(t, time.Now().AddDate(0, 0, -200), since, time.Hour)
+}
+
+func TestNextScannedThrough(t *testing.T) {
+	filters := &feed.Filters{}
+	watermark := time.Now().AddDate(0, 0, -100)
+	since := time.Now().AddDate(0, 0, -200)
+
+	result := &model.Feed{Episodes: []*model.Episode{
+		{ID: "a", PubDate: time.Now().AddDate(0, 0, -10)},
+		{ID: "b", PubDate: time.Now().AddDate(0, 0, -150)},
+	}}
+
+	t.Run("shallow keeps existing watermark", func(t *testing.T) {
+		got := nextScannedThrough(time.Time{}, watermark, result, map[string]struct{}{}, filters)
+		assert.Equal(t, watermark, got)
+	})
+
+	t.Run("shallow without watermark establishes baseline from oldest episode", func(t *testing.T) {
+		got := nextScannedThrough(time.Time{}, time.Time{}, result, map[string]struct{}{}, filters)
+		assert.WithinDuration(t, time.Now().AddDate(0, 0, -150), got, time.Hour)
+	})
+
+	t.Run("deep scan holds watermark until all matching episodes are processed", func(t *testing.T) {
+		// Only "a" is processed; "b" is still pending
+		got := nextScannedThrough(since, watermark, result, map[string]struct{}{"a": {}}, filters)
+		assert.Equal(t, watermark, got, "must not advance while episodes are still pending download")
+	})
+
+	t.Run("deep scan advances once all matching episodes are processed", func(t *testing.T) {
+		got := nextScannedThrough(since, watermark, result, map[string]struct{}{"a": {}, "b": {}}, filters)
+		assert.Equal(t, since, got)
+	})
+
+	t.Run("deep scan advances when only non-matching episodes are pending", func(t *testing.T) {
+		// "b" is excluded by the filter, so it must not block catch-up completion
+		f := &feed.Filters{MaxDuration: 60}
+		r := &model.Feed{Episodes: []*model.Episode{
+			{ID: "a", Duration: 30, PubDate: time.Now().AddDate(0, 0, -10)},
+			{ID: "b", Duration: 600, PubDate: time.Now().AddDate(0, 0, -150)},
+		}}
+		got := nextScannedThrough(since, watermark, r, map[string]struct{}{"a": {}}, f)
+		assert.Equal(t, since, got)
+	})
+}
+
+func TestDiscoveryWindowExistingFeedNoHistoryStaysShallow(t *testing.T) {
+	manager := newTestManager(t)
+	ctx := context.Background()
+
+	// Existing feed record with no ScannedThrough and only un-processed (New) episodes:
+	// there is no baseline to compare max_age against, so discovery must stay shallow.
+	require.NoError(t, manager.db.AddFeed(ctx, "1", &model.Feed{
+		ID:       "1",
+		Episodes: []*model.Episode{{ID: "x", Status: model.EpisodeNew, PubDate: time.Now().AddDate(0, 0, -10)}},
+	}))
+
+	since, _ := manager.discoveryWindow(ctx, &feed.Config{ID: "1", Filters: feed.Filters{MaxAge: 200}})
+	assert.True(t, since.IsZero(), "an existing feed with no scan baseline must stay shallow")
+}
+
+func TestOldestProcessedPubDate(t *testing.T) {
+	now := time.Now()
+
+	t.Run("ignores unprocessed and undated episodes", func(t *testing.T) {
+		episodes := []*model.Episode{
+			{ID: "new", Status: model.EpisodeNew, PubDate: now.AddDate(0, 0, -200)}, // not processed
+			{ID: "nodate", Status: model.EpisodeDownloaded},                         // zero PubDate
+			{ID: "dl", Status: model.EpisodeDownloaded, PubDate: now.AddDate(0, 0, -50)},
+			{ID: "cl", Status: model.EpisodeCleaned, PubDate: now.AddDate(0, 0, -100)},
+		}
+		assert.WithinDuration(t, now.AddDate(0, 0, -100), oldestProcessedPubDate(episodes), time.Hour)
+	})
+
+	t.Run("returns zero when nothing processed", func(t *testing.T) {
+		episodes := []*model.Episode{{ID: "new", Status: model.EpisodeNew, PubDate: now}}
+		assert.True(t, oldestProcessedPubDate(episodes).IsZero())
+	})
+}
+
+func TestOldestPubDate(t *testing.T) {
+	now := time.Now()
+	episodes := []*model.Episode{
+		{ID: "nodate"}, // zero PubDate is ignored
+		{ID: "a", PubDate: now.AddDate(0, 0, -10)},
+		{ID: "b", PubDate: now.AddDate(0, 0, -30)},
+	}
+	assert.WithinDuration(t, now.AddDate(0, 0, -30), oldestPubDate(episodes), time.Hour)
+}
+
+func TestCleanupPreservesMetadata(t *testing.T) {
+	ctx := context.Background()
+
+	dataDir := t.TempDir()
+	storage, err := fs.NewLocal(dataDir, false, false)
+	require.NoError(t, err)
+
+	manager := newTestManager(t)
+	manager.fs = storage
+
+	var (
+		recent = time.Now().AddDate(0, 0, -1)
+		old    = time.Now().AddDate(0, 0, -30)
+	)
+	seedEpisodes(t, manager, "1", []*model.Episode{
+		{ID: "recent", Title: "Recent", Description: "Recent desc", PubDate: recent, Status: model.EpisodeDownloaded},
+		{ID: "old", Title: "Old", Description: "Old desc", PubDate: old, Status: model.EpisodeDownloaded},
+	})
+
+	cfg := &feed.Config{ID: "1", Clean: &feed.Cleanup{KeepLast: 1}}
+
+	// Create the file that cleanup is expected to delete
+	_, err = storage.Create(ctx, "1/old.mp4", strings.NewReader("data"))
+	require.NoError(t, err)
+
+	require.NoError(t, manager.cleanup(ctx, cfg))
+
+	// The old episode is soft-deleted but keeps its metadata so it can be resurrected later
+	old1, err := manager.db.GetEpisode(ctx, "1", "old")
+	require.NoError(t, err)
+	assert.Equal(t, model.EpisodeCleaned, old1.Status)
+	assert.Equal(t, "Old", old1.Title)
+	assert.Equal(t, "Old desc", old1.Description)
+
+	// Its file is removed from storage
+	_, err = storage.Size(ctx, "1/old.mp4")
+	assert.Error(t, err)
+
+	// The recent episode is untouched
+	recent1, err := manager.db.GetEpisode(ctx, "1", "recent")
+	require.NoError(t, err)
+	assert.Equal(t, model.EpisodeDownloaded, recent1.Status)
+}
+
+func TestResurrectCleanedEpisodeMatchingFiltersAgain(t *testing.T) {
+	manager := newTestManager(t)
+	ctx := context.Background()
+
+	pubDate := time.Now().AddDate(0, 0, -30)
+	// Cleanup now preserves metadata, so the cleaned record keeps its title/description
+	cleaned := []*model.Episode{
+		{ID: "old", Title: "Old Episode", Description: "Description", PubDate: pubDate, Status: model.EpisodeCleaned},
+	}
+	seedEpisodes(t, manager, "1", cleaned)
+
+	cfg := &feed.Config{ID: "1", Filters: feed.Filters{MaxAge: 60}}
+
+	require.NoError(t, manager.resurrectEpisodes(cfg, cleaned, nil, nil))
+
+	episode, err := manager.db.GetEpisode(ctx, "1", "old")
+	require.NoError(t, err)
+	assert.Equal(t, model.EpisodeNew, episode.Status)
+	assert.Equal(t, "Old Episode", episode.Title)
+	assert.Equal(t, "Description", episode.Description)
+}
+
+func TestResurrectRecoversWipedMetadataFromAPIResult(t *testing.T) {
+	manager := newTestManager(t)
+	ctx := context.Background()
+
+	pubDate := time.Now().AddDate(0, 0, -30)
+	// A legacy cleaned episode whose title/description were wiped by older cleanup
+	cleaned := []*model.Episode{
+		{ID: "old", Duration: 600, PubDate: pubDate, Status: model.EpisodeCleaned},
+	}
+	seedEpisodes(t, manager, "1", cleaned)
+
+	// The deep-discovery scan brings the episode back into the feed query with fresh metadata
+	apiEpisodes := map[string]*model.Episode{
+		"old": {ID: "old", Title: "Recovered Title", Description: "Recovered Description"},
+	}
+
+	cfg := &feed.Config{ID: "1", Filters: feed.Filters{MaxAge: 60, MinDuration: 120}}
+
+	require.NoError(t, manager.resurrectEpisodes(cfg, cleaned, nil, apiEpisodes))
+
+	episode, err := manager.db.GetEpisode(ctx, "1", "old")
+	require.NoError(t, err)
+	assert.Equal(t, model.EpisodeNew, episode.Status)
+	assert.Equal(t, "Recovered Title", episode.Title)
+	assert.Equal(t, "Recovered Description", episode.Description)
+}
+
+func TestResurrectSkipsWipedEpisodeWithoutAPIMetadata(t *testing.T) {
+	manager := newTestManager(t)
+	ctx := context.Background()
+
+	pubDate := time.Now().AddDate(0, 0, -30)
+	// Legacy cleaned episode with no metadata, and not present in the current feed query
+	cleaned := []*model.Episode{
+		{ID: "old", Duration: 600, PubDate: pubDate, Status: model.EpisodeCleaned},
+	}
+	seedEpisodes(t, manager, "1", cleaned)
+
+	cfg := &feed.Config{ID: "1", Filters: feed.Filters{MaxAge: 60, MinDuration: 120}}
+
+	// No apiEpisodes: nothing to title the episode with, so it stays cleaned for now
+	require.NoError(t, manager.resurrectEpisodes(cfg, cleaned, nil, map[string]*model.Episode{}))
+
+	episode, err := manager.db.GetEpisode(ctx, "1", "old")
+	require.NoError(t, err)
+	assert.Equal(t, model.EpisodeCleaned, episode.Status)
+}
+
+func TestResurrectSkipsEpisodeFailingTextFilter(t *testing.T) {
+	manager := newTestManager(t)
+	ctx := context.Background()
+
+	pubDate := time.Now().AddDate(0, 0, -10)
+	// Passes duration/age, but the not_title filter excludes it after metadata is available
+	cleaned := []*model.Episode{
+		{ID: "old", Title: "Live Stream", PubDate: pubDate, Status: model.EpisodeCleaned},
+	}
+	seedEpisodes(t, manager, "1", cleaned)
+
+	cfg := &feed.Config{ID: "1", Filters: feed.Filters{MaxAge: 60, NotTitle: "(?i)live"}}
+
+	require.NoError(t, manager.resurrectEpisodes(cfg, cleaned, nil, nil))
+
+	episode, err := manager.db.GetEpisode(ctx, "1", "old")
+	require.NoError(t, err)
+	assert.Equal(t, model.EpisodeCleaned, episode.Status)
+}
+
+func TestResurrectSkipsEpisodeNotMatchingFilters(t *testing.T) {
+	manager := newTestManager(t)
+	ctx := context.Background()
+
+	pubDate := time.Now().AddDate(0, 0, -90)
+	cleaned := []*model.Episode{
+		{ID: "old", Title: "Old Episode", PubDate: pubDate, Status: model.EpisodeCleaned},
+	}
+	seedEpisodes(t, manager, "1", cleaned)
+
+	cfg := &feed.Config{ID: "1", Filters: feed.Filters{MaxAge: 60}}
+
+	require.NoError(t, manager.resurrectEpisodes(cfg, cleaned, nil, nil))
+
+	episode, err := manager.db.GetEpisode(ctx, "1", "old")
+	require.NoError(t, err)
+	assert.Equal(t, model.EpisodeCleaned, episode.Status)
+}
+
+func TestResurrectSkipsEpisodeThatWouldBeCleanedAgain(t *testing.T) {
+	manager := newTestManager(t)
+	ctx := context.Background()
+
+	var (
+		oldDate    = time.Now().AddDate(0, 0, -30)
+		recentDate = time.Now().AddDate(0, 0, -1)
+		downloaded = &model.Episode{ID: "recent", Title: "Recent", PubDate: recentDate, Status: model.EpisodeDownloaded}
+		old        = &model.Episode{ID: "old", Title: "Old Episode", PubDate: oldDate, Status: model.EpisodeCleaned}
+	)
+
+	seedEpisodes(t, manager, "1", []*model.Episode{old, downloaded})
+
+	// keep_last = 1 and a newer downloaded episode exists, so resurrecting
+	// the old one would result in cleanup deleting it again
+	cfg := &feed.Config{ID: "1", Clean: &feed.Cleanup{KeepLast: 1}}
+
+	require.NoError(t, manager.resurrectEpisodes(cfg, []*model.Episode{old}, []*model.Episode{downloaded}, nil))
+
+	episode, err := manager.db.GetEpisode(ctx, "1", "old")
+	require.NoError(t, err)
+	assert.Equal(t, model.EpisodeCleaned, episode.Status)
+}
+
+func TestResurrectKeepsEpisodeWithinKeepLastWindow(t *testing.T) {
+	manager := newTestManager(t)
+	ctx := context.Background()
+
+	var (
+		oldDate    = time.Now().AddDate(0, 0, -30)
+		recentDate = time.Now().AddDate(0, 0, -1)
+		downloaded = &model.Episode{ID: "recent", Title: "Recent", PubDate: recentDate, Status: model.EpisodeDownloaded}
+		old        = &model.Episode{ID: "old", Title: "Old Episode", PubDate: oldDate, Status: model.EpisodeCleaned}
+	)
+
+	seedEpisodes(t, manager, "1", []*model.Episode{old, downloaded})
+
+	cfg := &feed.Config{ID: "1", Clean: &feed.Cleanup{KeepLast: 2}}
+
+	require.NoError(t, manager.resurrectEpisodes(cfg, []*model.Episode{old}, []*model.Episode{downloaded}, nil))
+
+	episode, err := manager.db.GetEpisode(ctx, "1", "old")
+	require.NoError(t, err)
+	assert.Equal(t, model.EpisodeNew, episode.Status)
+	assert.Equal(t, "Old Episode", episode.Title)
+}
+
+func TestResurrectWithNoCleanedEpisodesDoesNothing(t *testing.T) {
+	manager := newTestManager(t)
+	ctx := context.Background()
+
+	pubDate := time.Now().AddDate(0, 0, -1)
+	seedEpisodes(t, manager, "1", []*model.Episode{
+		{ID: "done", Title: "Done", PubDate: pubDate, Status: model.EpisodeDownloaded},
+	})
+
+	cfg := &feed.Config{ID: "1"}
+
+	require.NoError(t, manager.resurrectEpisodes(cfg, nil, nil, nil))
+
+	episode, err := manager.db.GetEpisode(ctx, "1", "done")
+	require.NoError(t, err)
+	assert.Equal(t, model.EpisodeDownloaded, episode.Status)
+}


### PR DESCRIPTION
Hey @mxpv, I have a bit controversial PR for you. On several occasions, I needed to raise the `max_age` setting for a channel to go farther in history, and as you probably know, there is a design limitation that makes it a bit hard. 

Increasing a feed's max_age now pulls in older episodes that were previously out of range, instead of silently ignoring them. This required decoupling discovery depth from `page_size` and making episode re-inclusion work off the database rather than the API window to save API credits.

**Changes:**
- Discovery depth is driven by `max_age`: a normal update still does a shallow scan (`page_size` most-recent episodes), but when max_age is expanded beyond what was previously scanned, the YouTube builder performs a one-time deep scan that pages back to the `max_age` cutoff. A per-feed `ScannedThrough` high-water mark gates this so it costs nothing in steady state, and it is bounded by a 20-page backstop. Brand-new feeds stay shallow.
- Previously cleaned (soft-deleted) episodes that match the filters again are re-queued for download off the database records directly, independent of the `page_size` API window. Only episodes that would survive the `keep_last` cleanup are re-queued, to avoid a re-download/re-clean loop.
- Cleanup no longer clears an episode's title/description when soft-deleting it, so a re-included episode keeps its metadata. For episodes cleaned by older versions (which wiped metadata), the title/description are recovered from the current feed query.
- The feed build skips a downloaded episode with an empty title instead of aborting the whole feed, so one malformed item can no longer take down the entire feed.
- A startup warning is logged when `clean.keep_last` exceeds `page_size` and no `max_age` is configured.
- Currently implemented for YouTube.


It was a bit of a journey where I went through damaging some DB records on my side all the way to repairing them and having a behavior that doesn't shred through API credits unnecessarily.