### PR TITLE
Disable colors in file logs

### DIFF
--- a/cmd/podsync/main.go
+++ b/cmd/podsync/main.go
@@ -53,10 +53,11 @@ var (
 )
 
 func main() {
-	log.SetFormatter(&log.TextFormatter{
+	formatter := &log.TextFormatter{
 		TimestampFormat: time.RFC3339,
 		FullTimestamp:   true,
-	})
+	}
+	log.SetFormatter(formatter)
 
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
@@ -99,6 +100,7 @@ func main() {
 	if cfg.Log.Filename != "" {
 		log.Infof("Using log file: %s", cfg.Log.Filename)
 
+		formatter.DisableColors = true
 		log.SetOutput(&lumberjack.Logger{
 			Filename:   cfg.Log.Filename,
 			MaxSize:    cfg.Log.MaxSize,


### PR DESCRIPTION
When redirecting log output to a file, terminal escape codes are included. This PR removes them. Image shows before and after.

<img width="1687" height="595" alt="image" src="https://github.com/user-attachments/assets/e9caf681-94af-4fa1-8f3d-e2a67ea280be" />
