### PR TITLE
Make tests portable on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,14 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     permissions:
       contents: read
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
 
     steps:
       - uses: actions/setup-go@v7

--- a/cmd/podsync/config_test.go
+++ b/cmd/podsync/config_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -267,8 +268,8 @@ func TestDefaultHostname(t *testing.T) {
 
 func TestDefaultDatabasePath(t *testing.T) {
 	cfg := Config{}
-	cfg.applyDefaults("/home/user/podsync/config.toml")
-	assert.Equal(t, "/home/user/podsync/db", cfg.Database.Dir)
+	cfg.applyDefaults(filepath.Join("home", "user", "podsync", "config.toml"))
+	assert.Equal(t, filepath.Join("home", "user", "podsync", "db"), cfg.Database.Dir)
 }
 
 func TestLoadBadgerConfig(t *testing.T) {

--- a/pkg/feed/hooks_test.go
+++ b/pkg/feed/hooks_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,13 +19,19 @@ func TestExecuteHook_WriteEnvToFile(t *testing.T) {
 	tempDir := t.TempDir()
 	tempFile := filepath.Join(tempDir, "env_output.txt")
 
+	command := []string{"sh", "-c", `printenv | grep '^TEST_VAR=' > "$TEST_OUTPUT_FILE"`}
+	if runtime.GOOS == "windows" {
+		command = []string{"powershell.exe", "-NoProfile", "-Command", `[IO.File]::WriteAllText($env:TEST_OUTPUT_FILE, "TEST_VAR=" + $env:TEST_VAR)`}
+	}
+
 	hook := &ExecHook{
-		Command: []string{"sh", "-c", "printenv | grep '^TEST_VAR=' > " + tempFile},
+		Command: command,
 		Timeout: 5,
 	}
 
 	env := []string{
 		"TEST_VAR=test-value",
+		"TEST_OUTPUT_FILE=" + tempFile,
 	}
 
 	err := hook.Invoke(env)
@@ -73,7 +80,7 @@ func TestExecuteHook_CornerCases(t *testing.T) {
 		{
 			name: "successful command",
 			hook: &ExecHook{
-				Command: []string{"echo", "test"},
+				Command: []string{os.Args[0], "-test.run=^$"},
 			},
 			env:         []string{"TEST=value"},
 			expectError: false,
@@ -118,7 +125,7 @@ func TestExecuteHook_CurlWebhook(t *testing.T) {
 
 	// Use the local test server URL instead of external httpbin.org
 	hook := &ExecHook{
-		Command: []string{fmt.Sprintf("curl -s -X POST -d \"$EPISODE_TITLE\" %s", server.URL)},
+		Command: []string{"curl", "-s", "-X", "POST", "-d", "Test Episode for Webhook", server.URL},
 		Timeout: 10,
 	}
 

--- a/services/migrate/migrate_test.go
+++ b/services/migrate/migrate_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
-	"path/filepath"
+	"path"
 	"strings"
 	"testing"
 	"time"
@@ -108,7 +108,7 @@ func TestRunMigratesLegacyFilename(t *testing.T) {
 	}
 
 	legacyName := feed.LegacyEpisodeName(cfg, episode)
-	legacyPath := filepath.Join(feedID, legacyName)
+	legacyPath := path.Join(feedID, legacyName)
 	_, err = storage.Create(ctx, legacyPath, strings.NewReader("video-bytes"))
 	require.NoError(t, err)
 
@@ -117,7 +117,7 @@ func TestRunMigratesLegacyFilename(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
-	newPath := filepath.Join(feedID, feed.EpisodeName(cfg, episode))
+	newPath := path.Join(feedID, feed.EpisodeName(cfg, episode))
 	_, err = storage.Size(ctx, newPath)
 	require.NoError(t, err)
 
@@ -153,7 +153,7 @@ func TestRunDryRunDoesNotWrite(t *testing.T) {
 		FilenameTemplate: "{{pub_date}}_{{title}}_{{id}}",
 	}
 
-	legacyPath := filepath.Join(feedID, feed.LegacyEpisodeName(cfg, episode))
+	legacyPath := path.Join(feedID, feed.LegacyEpisodeName(cfg, episode))
 	_, err = storage.Create(ctx, legacyPath, strings.NewReader("video-bytes"))
 	require.NoError(t, err)
 
@@ -162,7 +162,7 @@ func TestRunDryRunDoesNotWrite(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
-	newPath := filepath.Join(feedID, feed.EpisodeName(cfg, episode))
+	newPath := path.Join(feedID, feed.EpisodeName(cfg, episode))
 	_, err = storage.Size(ctx, newPath)
 	require.Error(t, err)
 	assert.True(t, os.IsNotExist(err))
@@ -197,11 +197,11 @@ func TestRunFailsOnUnexpectedSecondTargetStatError(t *testing.T) {
 		FilenameTemplate: "{{pub_date}}_{{title}}_{{id}}",
 	}
 
-	legacyPath := filepath.Join(feedID, feed.LegacyEpisodeName(cfg, episode))
+	legacyPath := path.Join(feedID, feed.LegacyEpisodeName(cfg, episode))
 	_, err = baseStorage.Create(ctx, legacyPath, strings.NewReader("video-bytes"))
 	require.NoError(t, err)
 
-	newPath := filepath.Join(feedID, feed.EpisodeName(cfg, episode))
+	newPath := path.Join(feedID, feed.EpisodeName(cfg, episode))
 	storage := &flakySizeStorage{Storage: baseStorage, targetPath: newPath}
 
 	svc := New(map[string]*feed.Config{feedID: cfg}, tdb, storage, false)


### PR DESCRIPTION
Currently tests fail to run on Windows due to
* Path formatting
* Hook invocations (shell/curl)

This PR fixes these errors, and adds Windows to the CI test matrix to avoid future regressions.